### PR TITLE
adds missing headers

### DIFF
--- a/SDE/CMakeLists.txt
+++ b/SDE/CMakeLists.txt
@@ -19,6 +19,8 @@ set(SDE_INCLUDES detail_/Memoization.hpp
                  ModuleResult.hpp
                  PropertyType.hpp
                  SubmoduleRequest.hpp
+                 Types.hpp
+                 Utility.hpp
 )
 cpp_add_library(
     sde


### PR DESCRIPTION
This PR factors out of #68 the change that adds the missing header files so that hopefully Integrals will build off master.

This is r2g.
