### PR TITLE
Ensure ModuleInput::ready() returns

### DIFF
--- a/SDE/ModuleInput.cpp
+++ b/SDE/ModuleInput.cpp
@@ -20,7 +20,7 @@ bool ModuleInput::is_optional() const noexcept { return pimpl_->m_optional; }
 bool ModuleInput::is_transparent() const noexcept {
     return pimpl_->m_transparent;
 }
-bool ModuleInput::ready() const noexcept { pimpl_->is_ready(); }
+bool ModuleInput::ready() const noexcept { return pimpl_->is_ready(); }
 
 const type::description& ModuleInput::description() const noexcept {
     return pimpl_->m_desc;


### PR DESCRIPTION
## Status
<!--- Please check this box when your PR is ready--->
- [x] Ready to go

## Brief Description
Bug fix:  ModuleInput::ready() was not returning, relied on result of `pimpl->is_ready()` to be on the stack properly.

## Detailed Description (Optional)

## TODOs and/or Questions

