### PR TITLE
Use v2.13.3 tag for Catch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ if("${BUILD_TESTING}")
         URL github.com/catchorg/Catch2
         BUILD_TARGET Catch2
         FIND_TARGET Catch2::Catch2
+		VERSION v2.13.3
     )
     cpp_add_tests(
         test_sde


### PR DESCRIPTION
Build fails since Catch devs renamed master with devel, recently.
I see NWChemEx follows v2.x branch, but I think using a tag is safer
than an active branch to avoid similar problems in the future.

## Status
<!--- Please check this box when your PR is ready--->
- [x] Ready to go

## Brief Description

## Detailed Description (Optional)

## TODOs and/or Questions
<!--- When starting a PR early please add a list of things you plan on doing--->
