### PR TITLE
Moved tests into `tests/pluginplay` directory

### DIFF
--- a/docs/source/module_collections/document_modules.rst
+++ b/docs/source/module_collections/document_modules.rst
@@ -18,14 +18,14 @@ binary, which we will refer to as ``build_docs`` here. This program must
 include both the ``sde::printing::document_modules`` function and the
 ``load_modules`` function defined for your modules.
 
-.. literalinclude:: ../../../tests/docs/generate_module_documentation.cpp
+.. literalinclude:: ../../../tests/pluginplay/docs/generate_module_documentation.cpp
    :language: c++
    :lines: 1, 3-5
 
 Next, set up a ``sde::ModuleManager`` and load your modules with the
 ``load_modules`` you wrote.
 
-.. literalinclude:: ../../../tests/docs/generate_module_documentation.cpp
+.. literalinclude:: ../../../tests/pluginplay/docs/generate_module_documentation.cpp
    :language: c++
    :lines: 17-21
 
@@ -37,7 +37,7 @@ path is generated is a detail left to the developer's discretion. For simplicity
 in the example below, the first command line argument is assumed to be a valid
 path, although more validation may be necessary.
 
-.. literalinclude:: ../../../tests/docs/generate_module_documentation.cpp
+.. literalinclude:: ../../../tests/pluginplay/docs/generate_module_documentation.cpp
    :language: c++
    :lines: 23-24
 
@@ -50,6 +50,6 @@ The following code is a minimal example program generating documentation for
 the test modules in SDE. Modify the code according to the TODO comments to
 generate documentation for your modules.
 
-.. literalinclude:: ../../../tests/docs/generate_module_documentation.cpp
+.. literalinclude:: ../../../tests/pluginplay/docs/generate_module_documentation.cpp
    :language: c++
    :lines: 1-29

--- a/tests/pluginplay/docs/generate_module_documentation.cpp
+++ b/tests/pluginplay/docs/generate_module_documentation.cpp
@@ -1,12 +1,12 @@
 #include <filesystem>
-#include <sde/printing/document_modules.hpp>
+#include <pluginplay/printing/document_modules.hpp>
 
 // TODO: Replace with the header containing your ``load_modules`` definition
 #include "load_modules.hpp"
 
 namespace fs = std::filesystem;
 
-namespace sde_examples {
+namespace pluginplay_examples {
 
 int main(int argc, char** argv) {
     // Need docs_path
@@ -15,13 +15,13 @@ int main(int argc, char** argv) {
     fs::path docs_path(argv[1]);
 
     // Set up module manager
-    sde::ModuleManager mm;
+    pluginplay::ModuleManager mm;
 
     // TODO: Load your modules
-    sde_examples::load_modules(mm);
+    pluginplay_examples::load_modules(mm);
 
     // Generate module documentation at the given path
-    sde::printing::document_modules(mm, docs_path);
+    pluginplay::printing::document_modules(mm, docs_path);
 
     return 0;
 }

--- a/tests/pluginplay/printing/document_modules.cpp
+++ b/tests/pluginplay/printing/document_modules.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 #include <filesystem>
 #include <iterator>
-#include <sde/printing/document_modules.hpp>
+#include <pluginplay/printing/document_modules.hpp>
 
 #include "../docs/load_modules.hpp"
 
@@ -23,13 +23,13 @@ TEST_CASE("document_modules") {
                           fs::directory_iterator{}) == 0); // Empty directory
 
     // Set up module manager
-    sde::ModuleManager mm;
+    pluginplay::ModuleManager mm;
 
     SECTION("Empty Module Manager") {
         int correct = 1; // for index.html
 
         // Generate module documentation at the given path
-        sde::printing::document_modules(mm, docs_path);
+        pluginplay::printing::document_modules(mm, docs_path);
 
         REQUIRE(std::distance(fs::directory_iterator(docs_path),
                               fs::directory_iterator{}) == correct);
@@ -37,10 +37,10 @@ TEST_CASE("document_modules") {
 
     SECTION("Modules Loaded") {
         // Load your modules
-        sde_examples::load_modules(mm);
+        pluginplay_examples::load_modules(mm);
 
         // Generate module documentation at the given path
-        sde::printing::document_modules(mm, docs_path);
+        pluginplay::printing::document_modules(mm, docs_path);
 
         REQUIRE(std::distance(fs::directory_iterator(docs_path),
                               fs::directory_iterator{}) ==

--- a/tests/pluginplay/printing/helpers.cpp
+++ b/tests/pluginplay/printing/helpers.cpp
@@ -1,9 +1,10 @@
-#include "src/sde/printing/helpers.hpp"
 #include <catch2/catch.hpp>
 #include <iostream>
 #include <sstream>
 
-using namespace sde::printing;
+#include "../../../src/pluginplay/printing/helpers.hpp"
+
+using namespace pluginplay::printing;
 
 TEST_CASE("generate_index_string") {
     SECTION("Empty toc") {


### PR DESCRIPTION
## Status
<!--- Please check this box when your PR is ready--->
- [x] Ready to go

## Brief Description
There was a unit test file and example code file that did not get moved into the `tests/pluginplay` directory. I moved them and fixed the issues that arose from the move.

## Detailed Description (Optional)

## TODOs and/or Questions
<!--- When starting a PR early please add a list of things you plan on doing--->
- [x] Move `tests/printing/document_modules.cpp` into `tests/pluginplay/printing`.
- [x] Move `tests/docs/generate_module_documentation.cpp` into `tests/pluginplay/docs`.
    - [x] Fix file references in `docs/source/module_collections/document_modules.rst`.
- [x] Test that the moved unit tests are found, run, and pass.
- [x] Test that `docs/source/module_collections/document_modules.rst` renders properly.