### PR TITLE
CMake Module for Generating PluginPlay Module Docs

### DIFF
--- a/cmake/generate_module_docs.cpp.in
+++ b/cmake/generate_module_docs.cpp.in
@@ -1,0 +1,15 @@
+#include "@ppgmd_HEADER_PATH@"
+#include <cstdlib>
+#include <filesystem>
+#include <pluginplay/printing/document_modules.hpp>
+
+int main(){
+    const std::filesystem::path out("@ppgmd_OUTPUT_DIR@");
+    //std::filesystem::remove_all(out);
+    //std::filesystem::create_directory(out);
+
+    pluginplay::ModuleManager mm;
+    @ppgmd_LOAD_MODULES_FXN@(mm);
+    pluginplay::printing::document_modules(mm, out);
+    return EXIT_SUCCESS;
+}

--- a/cmake/make_module_docs.cmake
+++ b/cmake/make_module_docs.cmake
@@ -1,0 +1,52 @@
+include_guard()
+
+set(ppgmd_config_file "${CMAKE_CURRENT_LIST_DIR}/generate_module_docs.cpp.in")
+
+function(plugin_play_generate_module_docs)
+    set(ppgmd_one_val OUTPUT_DIR HEADER_PATH LOAD_MODULES_FXN DEPEND)
+    cmake_parse_arguments(ppgmd "" "${ppgmd_one_val}" "" ${ARGN})
+
+    set(
+        ppgmd_output_file
+        "${CMAKE_CURRENT_BINARY_DIR}/pp_module_docs/generate_module_docs.cpp"
+    )
+
+    configure_file("${ppgmd_config_file}" "${ppgmd_output_file}")
+    add_executable(generate_module_docs "${ppgmd_output_file}")
+    target_link_libraries(generate_module_docs "${ppgmd_DEPEND}")
+    add_dependencies(generate_module_docs "${ppgmd_DEPEND}")
+endfunction()
+
+#[[[ Convenience function for when the module collection follows usual
+#    conventions.
+#
+#    .. warning::
+#
+#       Calling the executable which results from this function will overwrite
+#       the contents of the output directory supplied to this function.
+#
+#    This function assumes your module collection's ``load_module`` function is
+#    included by including ``NAME/NAME.hpp``, the ``load_module``` function is
+#    in the namespace ``NAME`` and the name of the target which builds your
+#    module collection is also ``NAME``. If all of this is true supplying
+#    ``NAME``, and where you want the output, suffices to be able to call
+#    ``plugin_play_generate_module_docs``. If any of this is not the case, then
+#    you should go through the main ``plugin_play_generate_module_docs`` API.
+#
+#    :param ppgmdfn_name: The case-sensitive name of your module collection.
+#    :type ppgmdfn_name: str
+#    :param ppgmdfn_output: The full path of the directory where the files
+#                           should be written to. If the directory already
+#                           exists it will be overwritten when the executable is
+#                           run.
+#    :type ppgmdfn_output: path
+#
+#]]
+function(plugin_play_generate_module_docs_from_name ppgmdfn_name ppgmdfn_output)
+    plugin_play_generate_module_docs(
+        OUTPUT_DIR "${ppgmdfn_output}"
+        HEADER_PATH "${ppgmdfn_name}/${ppgmdfn_name}.hpp"
+        LOAD_MODULES_FXN "${ppgmdfn_name}::load_modules"
+        DEPEND "${ppgmdfn_name}"
+    )
+endfunction()


### PR DESCRIPTION
This PR starts some CMake infrastructure for making it easy to generate module documentation as part of CI. I'm probably not going to have time to return to this for a bit, but @zachcran if you have some spare cycles this should be pretty easy for you as it's just an extension of the documentation infrastructure you put in place previously.

The planned API will look something like:

```.cmake
include(make_module_docs)
plugin_play_generate_module_docs_from_name(
        ${CMAKE_PROJECT_NAME}
        "${CMAKE_CURRENT_LIST_DIR}/docs/source/module_apis"
    )
```

I'm not thrilled with putting generated files in the version-controlled documentation source (see the second TODO). Long term,  when PluginPlay is installable, I'd like `find_package(pluginplay)` to make the `plugin_play_generate_module_docs*` functions available rather than the user having to `include(make_module_docs)`.

# TODO

- [x] Fix directory setup. I biffed something, but when I run the resulting executable with `remove_all/create_directory` lines uncommented I erased the executable...
- [x] Is there a way to actually run Sphinx on the resulting files even though they're not the top-level documentation? I'm hoping this can be done similar to how we do Doxygen (basically in `docs/source/index.rst` we include a hyperlink to where we will put the resulting HTML).
- [x] Finish documenting the CMake module with CMinx style comments
- [ ] #205