### PR TITLE
Disable unportable unit tests for hashing

### DIFF
--- a/tests/pluginplay/detail_/any.cpp
+++ b/tests/pluginplay/detail_/any.cpp
@@ -11,7 +11,8 @@ TEST_CASE("Any : Default ctor") {
     Any a;
     REQUIRE_FALSE(a.has_value());
     REQUIRE(a.type() == typeid(void));
-    REQUIRE(pluginplay::hash_objects(a) == "cbc357ccb763df2852fee8c4fc7d55f2");
+    // REQUIRE(pluginplay::hash_objects(a) ==
+    // "cbc357ccb763df2852fee8c4fc7d55f2");
     REQUIRE_THROWS_AS(a.cast<double>(), std::bad_any_cast);
     REQUIRE(a.str() == "<empty Any>");
 }
@@ -21,8 +22,8 @@ TEST_CASE("Any : Value ctor") {
         Any a(int{3});
         REQUIRE(a.has_value());
         REQUIRE(a.type() == typeid(int));
-        REQUIRE(pluginplay::hash_objects(a) ==
-                "9a4294b64e60cc012c5ed48db4cd9c48");
+        // REQUIRE(pluginplay::hash_objects(a) ==
+        // "9a4294b64e60cc012c5ed48db4cd9c48");
         REQUIRE(a.cast<int>() == 3);
         REQUIRE(a.str() == "3");
     }
@@ -31,8 +32,8 @@ TEST_CASE("Any : Value ctor") {
         Any a(x);
         REQUIRE(a.has_value());
         REQUIRE(a.type() == typeid(int));
-        REQUIRE(pluginplay::hash_objects(a) ==
-                "9a4294b64e60cc012c5ed48db4cd9c48");
+        // REQUIRE(pluginplay::hash_objects(a) ==
+        // "9a4294b64e60cc012c5ed48db4cd9c48");
         REQUIRE(a.cast<int>() == 3);
         REQUIRE(a.str() == "3");
     }
@@ -41,8 +42,8 @@ TEST_CASE("Any : Value ctor") {
         Any a(x);
         REQUIRE(a.has_value());
         REQUIRE(a.type() == typeid(const int));
-        REQUIRE(pluginplay::hash_objects(a) ==
-                "9a4294b64e60cc012c5ed48db4cd9c48");
+        // REQUIRE(pluginplay::hash_objects(a) ==
+        // "9a4294b64e60cc012c5ed48db4cd9c48");
         REQUIRE(a.cast<int>() == 3);
         REQUIRE(a.str() == "3");
     }
@@ -52,8 +53,8 @@ TEST_CASE("Any : Value ctor") {
         Any a(std::move(x));
         REQUIRE(a.has_value());
         REQUIRE(a.type() == typeid(std::vector<int>));
-        REQUIRE(pluginplay::hash_objects(a) ==
-                "ad06a09d17cceb43c8d7f0283f889ef6");
+        // REQUIRE(pluginplay::hash_objects(a) ==
+        // "ad06a09d17cceb43c8d7f0283f889ef6");
         REQUIRE(a.cast<std::vector<int>&>().data() == px);
         REQUIRE(a.str() == "[1, 2, 3, 4]");
     }

--- a/tests/pluginplay/detail_/any_wrapper.cpp
+++ b/tests/pluginplay/detail_/any_wrapper.cpp
@@ -41,7 +41,12 @@ inline static void compare_value(T&& w, corr_t corr) {
     }
 
     SECTION("hashing") {
+#ifdef BPHASH_USE_TYPEID
+        REQUIRE_FALSE(pluginplay::hash_objects(corr) ==
+                      pluginplay::hash_objects(w));
+#else
         REQUIRE(pluginplay::hash_objects(corr) == pluginplay::hash_objects(w));
+#endif
     }
 }
 

--- a/tests/pluginplay/detail_/module_input_pimpl.cpp
+++ b/tests/pluginplay/detail_/module_input_pimpl.cpp
@@ -92,25 +92,25 @@ TEST_CASE("ModuleInputPIMPL : is_valid") {
     }
 }
 
-TEST_CASE("ModuleInputPIMPL : hash") {
-    ModuleInputPIMPL p;
-    p.set_type(std::type_index(typeid(int)));
-    SECTION("No value") {
-        REQUIRE(pluginplay::hash_objects(p) ==
-                "cbc357ccb763df2852fee8c4fc7d55f2");
-    }
-    SECTION("has value") {
-        p.set_value(make_Any<int>(3));
-        REQUIRE(pluginplay::hash_objects(p) ==
-                "9a4294b64e60cc012c5ed48db4cd9c48");
-    }
-    SECTION("is transparent") {
-        p.set_value(make_Any<int>(3));
-        p.make_transparent();
-        REQUIRE(pluginplay::hash_objects(p) ==
-                "00000000000000000000000000000000");
-    }
-}
+// TEST_CASE("ModuleInputPIMPL : hash") {
+//     ModuleInputPIMPL p;
+//     p.set_type(std::type_index(typeid(int)));
+//     SECTION("No value") {
+//         REQUIRE(pluginplay::hash_objects(p) ==
+//                 "cbc357ccb763df2852fee8c4fc7d55f2");
+//     }
+//     SECTION("has value") {
+//         p.set_value(make_Any<int>(3));
+//         REQUIRE(pluginplay::hash_objects(p) ==
+//                 "9a4294b64e60cc012c5ed48db4cd9c48");
+//     }
+//     SECTION("is transparent") {
+//         p.set_value(make_Any<int>(3));
+//         p.make_transparent();
+//         REQUIRE(pluginplay::hash_objects(p) ==
+//                 "00000000000000000000000000000000");
+//     }
+// }
 
 TEST_CASE("ModuleInputPIMPL : set_type") {
     ModuleInputPIMPL p;

--- a/tests/pluginplay/module_input.cpp
+++ b/tests/pluginplay/module_input.cpp
@@ -103,25 +103,25 @@ TEST_CASE("ModuleInput : is_valid") {
     }
 }
 
-TEST_CASE("ModuleInput : hash") {
-    ModuleInput i;
-    i.set_type<int>();
-    SECTION("Empty") {
-        REQUIRE(pluginplay::hash_objects(i) ==
-                "cbc357ccb763df2852fee8c4fc7d55f2");
-    }
-    SECTION("Has value and opaque") {
-        i.change(int{3});
-        REQUIRE(pluginplay::hash_objects(i) ==
-                "9a4294b64e60cc012c5ed48db4cd9c48");
-    }
-    SECTION("Has value and transparent") {
-        i.change(int{3});
-        i.make_transparent();
-        REQUIRE(pluginplay::hash_objects(i) ==
-                "00000000000000000000000000000000");
-    }
-}
+// TEST_CASE("ModuleInput : hash") {
+//     ModuleInput i;
+//     i.set_type<int>();
+//     SECTION("Empty") {
+//         REQUIRE(pluginplay::hash_objects(i) ==
+//                 "cbc357ccb763df2852fee8c4fc7d55f2");
+//     }
+//     SECTION("Has value and opaque") {
+//         i.change(int{3});
+//         REQUIRE(pluginplay::hash_objects(i) ==
+//                 "9a4294b64e60cc012c5ed48db4cd9c48");
+//     }
+//     SECTION("Has value and transparent") {
+//         i.change(int{3});
+//         i.make_transparent();
+//         REQUIRE(pluginplay::hash_objects(i) ==
+//                 "00000000000000000000000000000000");
+//     }
+// }
 
 TEST_CASE("ModuleInput: set_type") {
     ModuleInput i;


### PR DESCRIPTION
- Absolute hash comparisons are commented out, these can be enabled once we can verify hash values are portable.
- Unit tests that compare hashes relative to each other are branched depending on the type info is hashed, or not.
- Currently we use BPHASH_USE_TYPEID option to enable/disable adding type name to the hash.

- Needs to be merged before [ParallelZone PR #36](https://github.com/NWChemEx-Project/ParallelZone/pull/36) is merged. 

## Status
<!--- Please check this box when your PR is ready--->
- [ ] Ready to go

## Brief Description

## Detailed Description (Optional)

## TODOs and/or Questions
<!--- When starting a PR early please add a list of things you plan on doing--->
