### PR TITLE
Adds new AnyField, AnyInput, and AnyResult Classes

### DIFF
--- a/include/pluginplay/any/any.hpp
+++ b/include/pluginplay/any/any.hpp
@@ -6,6 +6,28 @@
 
 namespace pluginplay {
 
+/** @brief Creates an AnyResult by wrapping an object of type T.
+ *
+ *  @tparam T The unqualified (i.e. no cv-qualifiers or refernces) type of the
+ *            object that the AnyResult will wrap.
+ *  @tparam Args The types of the arguments which will be forwarded to T's ctor.
+ *
+ *  This free function wraps the process of creating an AnyResult around an
+ *  object of type @p T. The actual implmentation creates an object of type
+ *  @p T inplace by invoking @p T's ctor with @p args. In common usage, @p args
+ *  is a @p T instance and will invoke the copy or move ctor of @p T depending
+ *  on whether @p args is an lvalue or an rvalue.
+ *
+ *  This function will raise a static assert if @p T is anything other than an
+ *  unqualified type.
+ *
+ *  @param[in] args The arguments to use to construct an instance of type @p T.
+ *
+ *  @return An AnyResult instance which wraps the created @p T instance.
+ *
+ *  @throw ??? If the @p T ctor throws when invoked with @p args. Same throw
+ *             guarantee.
+ */
 template<typename T, typename... Args>
 auto make_any_result(Args&&... args) {
     using pimpl_type = detail_::AnyResultWrapper<T>;
@@ -13,8 +35,86 @@ auto make_any_result(Args&&... args) {
     return AnyResult(std::move(pimpl));
 }
 
+/** @brief Creates an AnyInput by wrapping an object of type T.
+ *
+ *  @tparam T The qualified (i.e. including cv-qualifiers and/or refernces) type
+ *            of the object that the AnyInput will wrap.
+ *  @tparam Args The types of the arguments which will be forwarded to T's ctor.
+ *
+ *  This free function wraps the process of creating an AnyInput around an
+ *  object of type @p T. The actual implmentation creates an object of type
+ *  @p T inplace by invoking @p T's ctor with @p args. In common usage, @p args
+ *  is a @p T instance and will invoke the copy or move ctor of @p T depending
+ *  on whether @p args is an lvalue or an rvalue.
+ *
+ *  This function will raise a static assert if @p T is a mutable reference.
+ *
+ *  @param[in] args The arguments to use to construct an instance of type @p T.
+ *
+ *  @return An AnyInput instance which wraps the created @p T instance.
+ *
+ *  @throw ??? If the @p T ctor throws when invoked with @p args. Same throw
+ *             guarantee.
+ */
+template<typename T, typename... Args>
+auto make_any_input(Args&&... args) {
+    using pimpl_type = detail_::AnyInputWrapper<T>;
+    using clean_type = std::decay_t<T>;
+    static_assert(!std::is_same_v<T, clean_type&>, "Can't wrap mutable ref");
+    auto pimpl = std::make_unique<pimpl_type>(T(std::forward<Args>(args)...));
+    return AnyInput(std::move(pimpl));
+}
+
+/** @brief Returns the object wrapped in either an AnyInput or an AnyField.
+ *
+ *  @tparam T The qualified type (i.e. including cv-qualifiers and references)
+ *            to return.
+ *  @tparam AnyType The type of the type-erased object we are unwrapping.
+ *                  Expected to be either an AnyInput or AnyField instance.
+ *
+ *  This free function is used to unwrap an AnyInput or an AnyField. To avoid
+ *  unnecessary copies users need to fully specify the type of object to unwrap.
+ *  In many cases @p T should be something like `const U&` where `U` is an
+ *  unqualified type (this example would return a read-only reference to an
+ *  instance of type `U`). The allowed types for unwrapping depend on whether
+ *  the any is an AnyInput or an AnyResult as well as the type of the wrapped
+ *  object. Assuming a wrapped object of type @p U it is always possible for
+ *  @p T to be:
+ *
+ *  - `std::decay_t<U>` (by mutable copy)
+ *  - `const std::decay_t<U>` (by read-only copy)
+ *  - `const std::decay_t<U>&` (by read-only reference)
+ *
+ *  Additionally, for AnyInputs which own mutable values one can retrieve
+ *  mutable references, i.e. `T = std::decay_t<u>&` is also allowed.
+ *
+ *  Conversions which are not allowed will either trip static assertions or
+ *  result in this function throwing `std::runtime_error` depending on whether
+ *  or not we know at compile time if a conversion is allowed. Attempting to
+ *  unwrap anything other than an AnyInput or an AnyResult will also lead to a
+ *  static assertion being tripped.
+ *
+ *  @note It is not possible to move a mutable value out of an AnyInput at this
+ *        time.
+ *
+ *  @param[in] da_any The type-erased input or result that we are unwrapping.
+ *
+ *  @return The object wrapped in @p da_any as an instance of type @p T.
+ *
+ *  @throw std::runtime_error if @p da_any does not currently wrap a value.
+ *                            Strong throw guarantee.
+ *
+ *  @throw std::runtime_error if the wrapped object can not be returned as an
+ *                            instance of type @p T. Strong throw guarantee.
+ */
 template<typename T, typename AnyType>
 T any_cast(AnyType&& da_any) {
+    using clean_type             = std::decay_t<AnyType>;
+    constexpr bool is_any_input  = std::is_same_v<clean_type, AnyInput>;
+    constexpr bool is_any_result = std::is_same_v<clean_type, AnyResult>;
+    static_assert(is_any_input || is_any_result,
+                  "da_any must be an AnyInput or an AnyResult.");
+
     return da_any.pimpl_().template cast<T>();
 }
 

--- a/include/pluginplay/any/any_input.hpp
+++ b/include/pluginplay/any/any_input.hpp
@@ -4,14 +4,220 @@
 
 namespace pluginplay {
 namespace detail_ {
-class AnyInputBase;
+class AnyInputBase; // Forward declare PIMPL
 }
 
+/** @brief Extends AnyField to Module inputs.
+ *
+ *  AnyInput instances type-erase inputs to modules. Module inputs are
+ *  restricted to being strictly inputs (i.e. they can not be mutable
+ *  references). PluginPlay allows inputs to be passed into a module in three
+ *  ways: by value, by const value, and by const reference. In the former two
+ *  scenarios the value is owned by the AnyInput instance, whereas in the latter
+ *  scenario the value is only aliased.
+ *
+ *  Retrieving a value from an AnyInput can always be done by copy, const copy,
+ *  or by const reference. Additionally, if the AnyInput owns a mutable copy of
+ *  the initial input value, users may retrieve the value from the AnyInput as a
+ *  mutable reference.
+ *
+ *  In addition to the methods provided by the AnyField class, the AnyInput
+ *  class also adds hashing capabilities. Consequently, values which are wrapped
+ *  in AnyInput instances must satisfy:
+ *  - copyable
+ *  - comparable (via operator==)
+ *  - hashable
+ */
 class AnyInput : public AnyField {
 public:
-    using hasher_type        = pluginplay::Hasher;
-    using hasher_reference   = hasher_type&;
-    using input_base_pointer = std::unique_ptr<detail_::AnyInputBase>;
+    /// Unqualified type of the object used for hashing
+    using hasher_type = pluginplay::Hasher;
+
+    /// Mutable reference to a hasher_type
+    using hasher_reference = hasher_type&;
+
+    /// Unqualified type of the PIMPL
+    using input_base = detail_::AnyInputBase;
+
+    /// How we store the PIMPL
+    using input_base_pointer = std::unique_ptr<input_base>;
+
+    /** @brief Creates an empty AnyInput
+     *
+     *  The default ctor creates an AnyInput which does not hold a value. The
+     *  only way to make the resulting instance hold a value is by assignment
+     *  or by swapping state with an AnyInput that does hold a value. The object
+     *  resulting from the default ctor is meant for use primarily as a
+     *  placeholder.
+     *
+     *  @throw None No throw guarantee.
+     */
+    AnyInput() noexcept;
+
+    /** @brief Value Ctor
+     *
+     *  This ctor creates a new AnyInput which wraps the provided value. The
+     *  value is provided to the AnyInput already wrapped up in a PIMPL
+     *  instance. Users who want to create a new AnyInput should use the
+     *  make_any_input free function, which wraps the process of creating the
+     *  PIMPL and forwarding it to this ctor.
+     *
+     *  @param[in] value The PIMPL this instance should use. Already contains
+     *                    the wrapped value.
+     *
+     *  @throw None No throw guarantee.
+     */
+    AnyInput(input_base_pointer value) noexcept;
+
+    /** @brief Creates a new AnyInput by copying another instance.
+     *
+     *  This ctor creates a new AnyInput by copying the state of another
+     *  instance. If the other instance owns the value (i.e., holds it by either
+     *  value or const value) the copy will be a deep copy (the exact definition
+     *  of what a deep copy is will depend on the copy ctor of wrapped object).
+     *  If the other instance aliases the wrapped value the resulting instance
+     *  will also alias the wrapped value. If the other instance does not wrap a
+     *  value, the newly created AnyInput will also not wrap a value.
+     *
+     *  @param[in] other The AnyInput whose state is being copied.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the new PIMPL.
+     *                        Strong throw guarantee.
+     *  @throw ??? If the wrapped value's ctor throws. Same throw guarantee.
+     */
+    AnyInput(const AnyInput& other);
+
+    /** @brief Creates a new AnyInput instance by taking another instance's
+     *         state.
+     *
+     *  This ctor creates a new AnyInput instance by taking ownership of another
+     *  instance's state. The actual move is done by taking the PIMPL pointer
+     *  from @p other. Consequently, any references to the wrapped instance will
+     *  continue to remain valid after this method is called.
+     *
+     *  @param[in,out] other The instance we are taking the state from. After
+     *                       this call @p other will be in a state consistent
+     *                       with default initialization.
+     *
+     * @throw None No throw guarantee.
+     */
+    AnyInput(AnyInput&& other) noexcept;
+
+    /** @brief Replaces the current instance's state with a copy of another
+     *         instance's state.
+     *
+     *  This method will overide the state of the current instance (in turn
+     *  deleting it) with a copy of another instance's state. The copy semantics
+     *  follow the AnyInput copy ctor (deep copy if @p rhs owns its value, and
+     *  shallow copy if @p rhs alisases its value).
+     *
+     *  @param[in] rhs The instance whose state is being copied.
+     *
+     *  @return The current instance, after replacing its internal state with a
+     *          copy of @p rhs's state.
+     *
+     *  @throw ??? If calling the AnyInput copy ctor on @p rhs throws. Same
+     *             throw guarantee.
+     */
+    AnyInput& operator=(const AnyInput& rhs);
+
+    /** @brief Overwrites the state of the current instance with the state of
+     *         another instance.
+     *
+     *  This method can be used to replace the state of the current instance
+     *  with the state of another instance. The state the present instance owns
+     *  prior to the call will be released (resulting in the wrapped object
+     *  being deleted if the AnyInput owned the value) before taking ownership
+     *  of @p rhs's state. The actual state is transferred by taking the PIMPL
+     *  pointer from @p rhs and thus all references to the value wrapped by
+     *  @p rhs remain valid after this operation.
+     *
+     *  @param[in,out] rhs The instance whose state is being taken. After this
+     *                     method is caleld @p rhs will be in a state consistent
+     *                     with being default initialized.
+     *
+     *  @return The current instance after taking ownership of @p rhs's state.
+     *
+     *  @throw None No throw guarantee.
+     */
+    AnyInput& operator=(AnyInput&& rhs) noexcept;
+
+    /// Default dtor
+    ~AnyInput() noexcept;
+
+    /** @brief Exchanges this instance's state with that of @p other.
+     *
+     *  This method is used to exchange the state of two AnyInput instances.
+     *  This is done by swapping the pointers to the PIMPLs. Consequently, all
+     *  references to the wrapped object remain valid after the operation.
+     *
+     *  @param[in,out] other The instance whose state is being swapped with the
+     *                       present instance's state. After this call @p other
+     *                       will contain the present instance's state.
+     *
+     *  @throw None No throw guarantee.
+     */
+    void swap(AnyInput& other) noexcept;
+
+    /** @brief Hashes the current instance.
+     *
+     *  Assuming the current instance wraps a value of qualified type T (i.e.
+     *  T includes cv-qualifiers and references). The wrapped object will be
+     *  hashed as an object of type `const std::decay_t<T>&` (the type being
+     *  relevant for hashers which also hash the type of the object).
+     *
+     *  This method is a no-op if the current instance does not wrap a value.
+     *
+     *  @param[in,out] h The object to use for hashing. After a call to this
+     *                   method the internal state of @p h will be updated to
+     *                   include a hash of the wrapped value.
+     */
+    void hash(hasher_reference h) const;
+
+protected:
+    /// Allows any_cast free function to actually cast the wrapped value
+    template<typename T, typename AnyType>
+    friend T any_cast(AnyType&&);
+
+    /// Type of the base class
+    using base_type = AnyField;
+
+    /// Type of a read-only reference to the base class's PIMPL
+    using typename base_type::const_field_base_reference;
+
+    /// Type of a mutable reference to the base class's PIMPL
+    using typename base_type::field_base_reference;
+
+    /// Type of a mutable reference to a input_base instance
+    using input_base_reference = input_base&;
+
+    /// Type of a read-only reference to an input_base instance
+    using const_input_base_reference = const input_base&;
+
+    /// Implements are_equal by comparing types
+    bool are_equal_(const base_type& rhs) const noexcept override;
+
+    /// Implements reset(), by calling m_pimpl_.reset()
+    void reset_() noexcept override;
+
+    /// Implements has_value() by casting m_pimpl_ to bool
+    bool has_value_() const noexcept override;
+
+    /// Upcasts the PIMPL to a mutable base class PIMPL, throws if no value
+    field_base_reference base_pimpl_() override;
+
+    /// Upcasts the PIMPL to a read-only base class PIMPL, throws if no value
+    const_field_base_reference base_pimpl_() const override;
+
+    /// Returns a mutable reference to the PIMPL, throws if no value
+    input_base_reference pimpl_();
+
+    /// Returns a read-only reference to the PIMPL, throws if no value
+    const_input_base_reference pimpl_() const;
+
+private:
+    /// The actual wrapped value
+    input_base_pointer m_pimpl_;
 };
 
 } // namespace pluginplay

--- a/include/pluginplay/any/any_result.hpp
+++ b/include/pluginplay/any/any_result.hpp
@@ -10,8 +10,14 @@ class AnyResultBase; // Forward declaration of the PIMPL
 /** @brief Type-erases module results.
  *
  *  This class extends the AnyField class to type-erased results. AnyResults are
- *  intended to hold the results that a module has computed.
+ *  intended to hold the results that a module has computed. Results are always
+ *  owned by the AnyResult (as opposed to an AnyInput which may alias its
+ *  wrapped value).
  *
+ *  The wrapped values must satisfy:
+ *  - Copyable
+ *  - Value comparable
+ *  - serializable (eventually)
  */
 class AnyResult : public AnyField {
 private:
@@ -48,9 +54,78 @@ public:
      */
     AnyResult(result_base_pointer pimpl) noexcept;
 
+    /** @brief Creates a new AnyResult by deep copying another instance.
+     *
+     *  This ctor initializes a new AnyResult with a deep copy of another
+     *  instance's state. In particular, if @p other does not contain a value,
+     *  the resulting AnyResult will also not contain a value. If @p other does
+     *  contain a value the resulting AnyResult will contain a deep copy of the
+     *  value @p other wraps.
+     *
+     *  @param[in] other The AnyResult we are copying.
+     *
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the memory for
+     *                        the PIMPL. Strong throw guarantee.
+     *  @throw ??? If the wrapped object's copy ctor throws. Same throw
+     *             guarantee.
+     */
     AnyResult(const AnyResult& other);
+
+    /** @brief Creates a new AnyResult by taking ownership of another instance's
+     *         state.
+     *
+     *  This ctor initializes a new AnyResult by taking ownership of @p other's
+     *  state. The actual ownership transfer occurs by transfering the PIMPL
+     *  pointer, thus all references and pointers to the wrapped value remain
+     *  valid after the transfer.
+     *
+     *  @param[in,out] other The instance whose state is being taken. After this
+     *                       call @p other behaves as if it had been default
+     *                       initialized.
+     *
+     *  @throw None No throw guarantee.
+     */
     AnyResult(AnyResult&& other) noexcept;
+
+    /** @brief Overrides the current instance's state with a deep copy of
+     *         another AnyResult.
+     *
+     *  This method will replace (and hence delete) any state held by the
+     *  current AnyResult. After the operation the present AnyResult will
+     *  contain a deep copy of the state contained in @p rhs. For all intents
+     *  and purposes it is as if the present instance had been copy constructed
+     *  from @p rhs.
+     *
+     *  @param[in] rhs The AnyResult whose state is being copied.
+     *
+     *  @return The current instance, after overriding its state with a copy of
+     *          @p rhs.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the memory for
+     *                        the new PIMPL. Strong throw guarantee.
+     *  @throw ??? If the copy ctor of the wrapped value throws. Same throw
+     *             guarantee.
+     */
     AnyResult& operator=(const AnyResult& rhs);
+
+    /** @brief Overrides the current instance's state with the state of another
+     *         AnyResult.
+     *
+     *  This method will replace (and hence delete) any state held by the
+     *  current AnyResult. After the operation the present AnyResult will
+     *  contain the state that was previously in @p rhs. The actual transfer of
+     *  state occurs by transferring the PIMPL pointer and thus all references
+     *  to @p rhs's state remain valid after this call.
+     *
+     *  @param[in,out] rhs The AnyResult whose state is being taken. After this
+     *                     call AnyResult will be in a default initialized
+     *                     state.
+     *
+     *  @return The current instanc, after taking ownership of @p rhs's state.
+     *
+     *  @throw None No throw guarantee.
+     */
     AnyResult& operator=(AnyResult&& rhs) noexcept;
 
     /// Standard default dtor
@@ -88,17 +163,20 @@ protected:
     /// Type of a read-only reference to a a result_base instance
     using const_result_base_reference = const result_base&;
 
+    /// Implements are_equal by comparing types
+    bool are_equal_(const base_type& rhs) const noexcept override;
+
     /// Implements reset(), by calling m_pimpl_.reset()
     void reset_() noexcept override;
 
     /// Implements has_value() by casting m_pimpl_ to bool
-    bool has_value_() const noexcept;
+    bool has_value_() const noexcept override;
 
     /// Upcasts the PIMPL to a mutable base class PIMPL, throws if no value
-    field_base_reference base_pimpl_() noexcept override;
+    field_base_reference base_pimpl_() override;
 
     /// Upcasts the PIMPL to a read-only base class PIMPL, throws if no value
-    const_field_base_reference base_pimpl_() const noexcept override;
+    const_field_base_reference base_pimpl_() const override;
 
     /// Returns a mutable reference to the PIMPL, throws if no value
     result_base_reference pimpl_();

--- a/src/pluginplay/any/any_field.cpp
+++ b/src/pluginplay/any/any_field.cpp
@@ -10,8 +10,13 @@ typename AnyField::rtti_type AnyField::type() const noexcept {
 }
 
 bool AnyField::are_equal(const AnyField& rhs) const noexcept {
+    return are_equal_(rhs) && rhs.are_equal_(*this);
+}
+
+bool AnyField::are_equal_(const AnyField& rhs) const noexcept {
     // Take care of xor condition (which means they're not equal)
     if(has_value() != rhs.has_value()) return false;
+
     if(!has_value()) return true; // Both of them must not have a value
 
     // Getting here means they both have a value, compare it

--- a/src/pluginplay/any/any_input.cpp
+++ b/src/pluginplay/any/any_input.cpp
@@ -1,0 +1,74 @@
+#include "pluginplay/any/any_input.hpp"
+#include "pluginplay/any/detail_/any_input_base.hpp"
+
+namespace pluginplay {
+
+// -- CTors and Assignment -----------------------------------------------------
+
+AnyInput::AnyInput() noexcept = default;
+
+AnyInput::AnyInput(input_base_pointer value) noexcept :
+  m_pimpl_(std::move(value)) {}
+
+AnyInput::AnyInput(const AnyInput& other) :
+  m_pimpl_(other.has_value() ? other.m_pimpl_->clone() : nullptr) {}
+
+AnyInput::AnyInput(AnyInput&& other) noexcept :
+  m_pimpl_(std::move(other.m_pimpl_)) {}
+
+AnyInput& AnyInput::operator=(const AnyInput& rhs) {
+    if(this == &rhs) return *this;
+    AnyInput(rhs).swap(*this);
+    return *this;
+}
+
+AnyInput& AnyInput::operator=(AnyInput&& rhs) noexcept {
+    if(this == &rhs) return *this;
+    m_pimpl_ = std::move(rhs.m_pimpl_);
+    return *this;
+}
+
+AnyInput::~AnyInput() noexcept = default;
+
+// -- Public methods -----------------------------------------------------------
+
+void AnyInput::swap(AnyInput& other) noexcept { m_pimpl_.swap(other.m_pimpl_); }
+
+void AnyInput::hash(hasher_reference h) const {
+    if(has_value()) m_pimpl_->do_hash(h);
+}
+
+// -- Protected methods --------------------------------------------------------
+
+bool AnyInput::are_equal_(const base_type& rhs) const noexcept {
+    auto p = dynamic_cast<const AnyInput*>(&rhs);
+    return p == nullptr ? false : base_type::are_equal_(rhs);
+}
+
+void AnyInput::reset_() noexcept { m_pimpl_.reset(); }
+
+bool AnyInput::has_value_() const noexcept {
+    return static_cast<bool>(m_pimpl_);
+}
+
+typename AnyInput::field_base_reference AnyInput::base_pimpl_() {
+    assert_value_();
+    return *m_pimpl_;
+}
+
+typename AnyInput::const_field_base_reference AnyInput::base_pimpl_() const {
+    assert_value_();
+    return *m_pimpl_;
+}
+
+typename AnyInput::input_base_reference AnyInput::pimpl_() {
+    assert_value_();
+    return *m_pimpl_;
+}
+
+typename AnyInput::const_input_base_reference AnyInput::pimpl_() const {
+    assert_value_();
+    return *m_pimpl_;
+}
+
+} // namespace pluginplay

--- a/src/pluginplay/any/any_result.cpp
+++ b/src/pluginplay/any/any_result.cpp
@@ -28,19 +28,25 @@ AnyResult& AnyResult::operator=(AnyResult&& rhs) noexcept {
 
 AnyResult::~AnyResult() noexcept = default;
 
+// -- Protected Methods --------------------------------------------------------
+
+bool AnyResult::are_equal_(const base_type& rhs) const noexcept {
+    auto p = dynamic_cast<const AnyResult*>(&rhs);
+    return p == nullptr ? false : base_type::are_equal_(rhs);
+}
+
 void AnyResult::reset_() noexcept { m_pimpl_.reset(); }
 
 bool AnyResult::has_value_() const noexcept {
     return static_cast<bool>(m_pimpl_);
 }
 
-typename AnyResult::field_base_reference AnyResult::base_pimpl_() noexcept {
+typename AnyResult::field_base_reference AnyResult::base_pimpl_() {
     assert_value_();
     return *m_pimpl_;
 }
 
-typename AnyResult::const_field_base_reference AnyResult::base_pimpl_()
-  const noexcept {
+typename AnyResult::const_field_base_reference AnyResult::base_pimpl_() const {
     assert_value_();
     return *m_pimpl_;
 }

--- a/tests/pluginplay/any/any.cpp
+++ b/tests/pluginplay/any/any.cpp
@@ -53,3 +53,57 @@ TEMPLATE_LIST_TEST_CASE("make_any_result", "", testing::types2test) {
         REQUIRE(p == any_cast<const type&>(moved).data());
     }
 }
+
+TEMPLATE_LIST_TEST_CASE("make_any_input", "", testing::types2test) {
+    using type    = TestType;
+    using error_t = std::runtime_error;
+
+    auto value = testing::non_default_value<type>();
+
+    auto has_value = make_any_input<type>(value);
+    auto has_cval  = make_any_input<const type>(value);
+    auto has_cref  = make_any_input<const type&>(value);
+
+    //
+    // The following 2 tests should raise static asserts (uncomment to test)
+    //
+    // REQUIRE_THROWS_AS(make_any_input<type&>(value), error_t);
+    // REQUIRE_THROWS_AS(any_cast<type>(value), error_t);
+
+    // Can get the value back by copy
+    REQUIRE(any_cast<type>(has_value) == value);
+    REQUIRE(any_cast<type>(has_cval) == value);
+    REQUIRE(any_cast<type>(has_cref) == value);
+
+    // Can get the value back by read-only copy
+    REQUIRE(any_cast<const type>(has_value) == value);
+    REQUIRE(any_cast<const type>(has_cval) == value);
+    REQUIRE(any_cast<const type>(has_cref) == value);
+
+    // Can get the value back by mutable reference (when we're allowed to)
+    REQUIRE(any_cast<type&>(has_value) == value);
+    REQUIRE_THROWS_AS(any_cast<type&>(has_cval), error_t);
+    REQUIRE_THROWS_AS(any_cast<type&>(has_cref), error_t);
+
+    // Can get the value back by read-only reference
+    REQUIRE(any_cast<const type&>(has_value) == value);
+    REQUIRE(any_cast<const type&>(has_cval) == value);
+    REQUIRE(any_cast<const type&>(has_cref) == value);
+
+    // Additional check that no copy occurred when wrapped by cref
+    REQUIRE(&any_cast<const type&>(has_cref) == &value);
+
+    // Throws if wrapped value isn't convertible to requested type
+    REQUIRE_THROWS_AS(any_cast<error_t>(has_value), error_t);
+
+    // Throws if AnyInput is empty
+    REQUIRE_THROWS_AS(any_cast<type>(AnyInput{}), error_t);
+
+    // Ensures that we actually move the value into the AnyInput and don't
+    // copy it.
+    if constexpr(std::is_same_v<type, std::vector<int>>) {
+        const auto* p = value.data();
+        auto moved    = make_any_input<type>(std::move(value));
+        REQUIRE(p == any_cast<const type&>(moved).data());
+    }
+}

--- a/tests/pluginplay/any/any_input.cpp
+++ b/tests/pluginplay/any/any_input.cpp
@@ -1,0 +1,171 @@
+#include "pluginplay/any/any.hpp"
+
+#include "test_any.hpp"
+
+using namespace pluginplay;
+
+TEMPLATE_LIST_TEST_CASE("AnyInput", "", testing::types2test) {
+    using type       = TestType;
+    using input_type = AnyInput;
+    using rtti_type  = typename input_type::rtti_type;
+
+    auto value = testing::non_default_value<type>();
+
+    input_type defaulted;
+    input_type by_value = make_any_input<type>(value);
+    input_type by_cval  = make_any_input<const type>(value);
+    input_type by_cref  = make_any_input<const type&>(value);
+
+    SECTION("Ctors") {
+        SECTION("Default Ctor") {
+            REQUIRE_FALSE(defaulted.has_value());
+            REQUIRE(defaulted.type() == rtti_type(typeid(nullptr)));
+        }
+
+        SECTION("Value Ctor") {
+            REQUIRE(by_value.has_value());
+            REQUIRE(by_value.type() == rtti_type(typeid(type)));
+            REQUIRE(any_cast<type>(by_value) == value);
+
+            REQUIRE(by_cval.has_value());
+            REQUIRE(by_cval.type() == rtti_type(typeid(type)));
+            REQUIRE(any_cast<const type>(by_cval) == value);
+
+            REQUIRE(by_cref.has_value());
+            REQUIRE(by_cref.type() == rtti_type(typeid(type)));
+            REQUIRE(&any_cast<const type&>(by_cref) == &value);
+        }
+
+        SECTION("Copy Ctor") {
+            input_type default_copy(defaulted);
+            REQUIRE(default_copy.are_equal(defaulted));
+
+            input_type val_copy(by_value);
+            REQUIRE(val_copy.are_equal(by_value));
+
+            input_type cval_copy(by_cval);
+            REQUIRE(cval_copy.are_equal(by_cval));
+
+            input_type cref_copy(by_cref);
+            REQUIRE(cref_copy.are_equal(by_cref));
+
+            // Copy aliases the same object (doesn't deep copy it)
+            REQUIRE(&any_cast<const type&>(cref_copy) == &value);
+        }
+
+        SECTION("Move Ctor") {
+            input_type default_copy(defaulted);
+            input_type default_move(std::move(defaulted));
+            REQUIRE(default_copy.are_equal(default_move));
+
+            input_type val_copy(by_value);
+            input_type val_move(std::move(by_value));
+            REQUIRE(val_copy.are_equal(val_move));
+
+            input_type cval_copy(by_cval);
+            input_type cval_move(std::move(by_cval));
+            REQUIRE(cval_copy.are_equal(cval_move));
+
+            input_type cref_copy(by_cref);
+            input_type cref_move(std::move(by_cref));
+            REQUIRE(cref_copy.are_equal(cref_move));
+
+            // Still aliases the same object (doesn't deep copy it)
+            REQUIRE(&any_cast<const type&>(cref_move) == &value);
+        }
+
+        SECTION("Copy Assignment") {
+            input_type default_copy;
+            auto p = &(default_copy = defaulted);
+            REQUIRE(p == &default_copy);
+            REQUIRE(default_copy.are_equal(defaulted));
+
+            input_type val_copy;
+            p = &(val_copy = by_value);
+            REQUIRE(p == &val_copy);
+            REQUIRE(val_copy.are_equal(by_value));
+
+            input_type cval_copy;
+            p = &(cval_copy = by_cval);
+            REQUIRE(p == &cval_copy);
+            REQUIRE(cval_copy.are_equal(by_cval));
+
+            input_type cref_copy;
+            p = &(cref_copy = by_cref);
+            REQUIRE(cref_copy.are_equal(by_cref));
+
+            // Copy aliases the same object (doesn't deep copy it)
+            REQUIRE(&any_cast<const type&>(cref_copy) == &value);
+        }
+
+        SECTION("Move Ctor") {
+            input_type default_copy(defaulted);
+            input_type default_move;
+            auto p = &(default_move = std::move(defaulted));
+            REQUIRE(p == &default_move);
+            REQUIRE(default_copy.are_equal(default_move));
+
+            input_type val_copy(by_value);
+            input_type val_move;
+            p = &(val_move = std::move(by_value));
+            REQUIRE(p == &val_move);
+            REQUIRE(val_copy.are_equal(val_move));
+
+            input_type cval_copy(by_cval);
+            input_type cval_move;
+            p = &(cval_move = std::move(by_cval));
+            REQUIRE(p == &cval_move);
+            REQUIRE(cval_copy.are_equal(cval_move));
+
+            input_type cref_copy(by_cref);
+            input_type cref_move;
+            p = &(cref_move = std::move(by_cref));
+            REQUIRE(p == &cref_move);
+            REQUIRE(cref_copy.are_equal(cref_move));
+
+            // Still aliases the same object (doesn't deep copy it)
+            REQUIRE(&any_cast<const type&>(cref_move) == &value);
+        }
+    }
+
+    SECTION("swap") {
+        defaulted.swap(by_value);
+        REQUIRE(by_value.are_equal(AnyInput{}));
+        REQUIRE(defaulted.are_equal(make_any_input<type>(value)));
+
+        defaulted.swap(by_cval);
+        REQUIRE(defaulted.are_equal(make_any_input<const type>(value)));
+        REQUIRE(by_cval.are_equal(make_any_input<type>(value)));
+
+        defaulted.swap(by_cref);
+        REQUIRE(defaulted.are_equal(make_any_input<const type&>(value)));
+        REQUIRE(by_cref.are_equal(make_any_input<const type>(value)));
+    }
+
+    SECTION("hash") {
+        auto h_default = hash_objects(defaulted);
+        auto h_value   = hash_objects(by_value);
+        auto h_cval    = hash_objects(by_cval);
+        auto h_cref    = hash_objects(by_cref);
+
+        // Defaults are equal
+        auto h_default2 = hash_objects(input_type{});
+        REQUIRE(h_default == h_default2);
+
+        // Values are equal
+        auto h_value2 = hash_objects(make_any_input<type>(value));
+        REQUIRE(h_value == h_value2);
+
+        // Default != value
+        REQUIRE(h_default != h_value);
+
+        // Value == const Value
+        REQUIRE(h_value == h_cval);
+
+        // Value == const ref
+        REQUIRE(h_value == h_cref);
+
+        // const value == const ref
+        REQUIRE(h_cval == h_cref);
+    }
+}

--- a/tests/pluginplay/any/detail_/any_input_wrapper.cpp
+++ b/tests/pluginplay/any/detail_/any_input_wrapper.cpp
@@ -147,13 +147,13 @@ TEMPLATE_LIST_TEST_CASE("AnyInputWrapper", "", testing::types2test) {
         // Default != value
         REQUIRE(h_default != h_value);
 
-        // Value != const Value
+        // Value == const Value
         REQUIRE(h_value == h_cval);
 
-        // Value != const ref
+        // Value == const ref
         REQUIRE(h_value == h_cref);
 
-        // const value != const ref
+        // const value == const ref
         REQUIRE(h_cval == h_cref);
     }
 


### PR DESCRIPTION
This PR finishes off the new AnyInput/AnyResult classes. It closes #213 and #214.

Still todo:
- AnyInput
- documentation
- unit testing