### PR TITLE
Enable  optional testing for dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ include(get_cpp)
 
 ### Options ###
 option(BUILD_TESTING "Should we build the tests?" OFF)
+option(PARALLELZONE_BUILD_TESTING "Should we build the tests for ParallelZone?" OFF)
+option(UTILITIES_BUILD_TESTING "Should we build the tests for Utilities?" OFF)
 option(BUILD_DOCS "Should we build the documentation?" OFF)
 option(
     ONLY_BUILD_DOCS
@@ -46,7 +48,7 @@ cpp_find_or_build_dependency(
     URL github.com/seleznevae/libfort
     BUILD_TARGET fort
     FIND_TARGET libfort::fort
-    CMAKE_ARGS FORT_ENABLE_TESTING=${FORT_BUILD_TESTING}
+    CMAKE_ARGS FORT_ENABLE_TESTING=OFF
 )
 
 cpp_find_or_build_dependency(


### PR DESCRIPTION
Currently, we cannot enable tests for dependencies without modifying `CMakeLists.txt`.

This change will not alter the default behavior of not building
tests for dependencies. One needs to set these variables explicitly
in the toolchain file `set(PARALLELZONE_BUILD_TESTING ON)`, or as a
command line argument `cmake -DPARALLELZONE_BUILD_TESTING=ON`.

## Status
<!--- Please check this box when your PR is ready--->
- [x] Ready to go

## Brief Description

## Detailed Description (Optional)

## TODOs and/or Questions
If this PR is approved, I can do the same for the other repos.
<!--- When starting a PR early please add a list of things you plan on doing--->
