### PR TITLE
Update to RuntimeView

### DIFF
--- a/include/pluginplay/module_base.hpp
+++ b/include/pluginplay/module_base.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <memory>
-#include <parallelzone/runtime.hpp>
+#include <parallelzone/runtime/runtime_view.hpp>
 #include <pluginplay/cache/cache.hpp>
 #include <pluginplay/fields/fields.hpp>
 #include <pluginplay/submodule_request.hpp>
@@ -44,7 +44,7 @@ public:
     using cache_ptr = typename mm_cache::user_cache_pointer;
 
     /// The type of the runtime
-    using runtime_type = parallelzone::Runtime;
+    using runtime_type = parallelzone::runtime::RuntimeView;
 
     /// A pointer to a runtime
     using runtime_ptr = std::shared_ptr<runtime_type>;

--- a/include/pluginplay/module_manager.hpp
+++ b/include/pluginplay/module_manager.hpp
@@ -3,7 +3,7 @@
 #include "pluginplay/module_base.hpp"
 #include "pluginplay/types.hpp"
 #include <memory>
-#include <parallelzone/runtime.hpp>
+#include <parallelzone/runtime/runtime_view.hpp>
 
 namespace pluginplay {
 
@@ -26,7 +26,7 @@ public:
     using module_map = utilities::CaseInsensitiveMap<std::shared_ptr<Module>>;
 
     // The type of the runtime
-    using runtime_type = parallelzone::Runtime;
+    using runtime_type = parallelzone::runtime::RuntimeView;
 
     /// A pointer to a runtime
     using runtime_ptr = std::shared_ptr<runtime_type>;

--- a/src/pluginplay/detail_/module_manager_pimpl.hpp
+++ b/src/pluginplay/detail_/module_manager_pimpl.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "module_pimpl.hpp"
 #include <memory>
-#include <parallelzone/runtime.hpp>
+#include <parallelzone/runtime/runtime_view.hpp>
 #include <pluginplay/cache/module_manager_cache.hpp>
 #include <pluginplay/module_base.hpp>
 #include <pluginplay/module_manager.hpp>
@@ -40,7 +40,7 @@ struct ModuleManagerPIMPL {
     using default_map = std::map<std::type_index, type::key>;
 
     /// The type of the runtime
-    using runtime_type = parallelzone::Runtime;
+    using runtime_type = parallelzone::runtime::RuntimeView;
 
     /// A pointer to a runtime
     using runtime_ptr = std::shared_ptr<runtime_type>;

--- a/tests/pluginplay/detail_/module_manager_pimpl.cpp
+++ b/tests/pluginplay/detail_/module_manager_pimpl.cpp
@@ -21,14 +21,14 @@ TEST_CASE("ModuleManagerPIMPL : Default ctor") {
 
 TEST_CASE("ModuleManagerPIMPL : Runtime") {
     SECTION("ctor") {
-        auto runtime = std::make_shared<parallelzone::Runtime>();
+        auto runtime = std::make_shared<parallelzone::runtime::RuntimeView>();
         ModuleManagerPIMPL pimple(runtime);
         auto& internal_runtime = pimple.get_runtime();
         REQUIRE(&internal_runtime == runtime.get());
     }
     SECTION("set_runtime") {
         ModuleManagerPIMPL pimple;
-        auto runtime = std::make_shared<parallelzone::Runtime>();
+        auto runtime = std::make_shared<parallelzone::runtime::RuntimeView>();
 
         auto& internal_runtime1 = pimple.get_runtime();
         REQUIRE(&internal_runtime1 != runtime.get());

--- a/tests/pluginplay/module_base.cpp
+++ b/tests/pluginplay/module_base.cpp
@@ -1,6 +1,6 @@
 #include "test_common.hpp"
 #include <catch2/catch.hpp>
-#include <parallelzone/runtime.hpp>
+#include <parallelzone/runtime/runtime_view.hpp>
 #include <pluginplay/module_base.hpp>
 
 using namespace pluginplay;
@@ -125,7 +125,7 @@ TEST_CASE("ModuleBase : get_runtime") {
     }
 
     SECTION("Works if there's a runtime") {
-        auto runtime = std::make_shared<parallelzone::Runtime>();
+        auto runtime = std::make_shared<parallelzone::runtime::RuntimeView>();
         mod.set_runtime(runtime);
         auto& internal_runtime = mod.get_runtime();
         REQUIRE(&internal_runtime == runtime.get());

--- a/tests/pluginplay/test_main.cpp
+++ b/tests/pluginplay/test_main.cpp
@@ -1,9 +1,9 @@
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
-#include <parallelzone/runtime.hpp>
+#include <parallelzone/runtime/runtime_view.hpp>
 
 int main(int argc, char* argv[]) {
-    auto rt = parallelzone::Runtime(argc, argv);
+    auto rt = parallelzone::runtime::RuntimeView(argc, argv);
 
     int res = Catch::Session().run(argc, argv);
 


### PR DESCRIPTION
Changes the `runtime_type` to the new `RuntimeView`. This is just spot fixing due to API break. The actual application/usage of the runtime should be looked at again once ParallelZone is matured.