### PR TITLE
adds keys() function

### DIFF
--- a/src/pluginplay/cache/database/database_api.hpp
+++ b/src/pluginplay/cache/database/database_api.hpp
@@ -70,6 +70,22 @@ public:
     /// No-op, no-throw polymorphic default dtor
     virtual ~DatabaseAPI() noexcept = default;
 
+    /** @brief Returns a container with the keys for the database.
+     *
+     *  One of the most accessible ways to iterate over a database is by
+     *  looping over the keys and then retrieving the values ("accessible"
+     *  because not all backends expose key/value pairs).
+     *
+     *  N.B. This operation, as implemented, can be very expensive because in
+     *  general the keys will need to be copied into the returned object.
+     *  Furthermore, for some of the layers relying on proxies, this method
+     *  can result in multiple copies of the unproxied objects.
+     *
+     *  @return A container with the database's keys.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating. Strong throw
+     *                        gurantee.
+     */
     key_set_type keys() const { return keys_(); }
 
     /** @brief Public API for determining if a database contains a key.

--- a/src/pluginplay/cache/database/database_api.hpp
+++ b/src/pluginplay/cache/database/database_api.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "db_value.hpp"
 #include <stdexcept>
+#include <vector>
 
 namespace pluginplay::cache::database {
 
@@ -21,6 +22,9 @@ class DatabaseAPI {
 public:
     /// Type used to store the keys in the database, same as @p KeyType
     using key_type = KeyType;
+
+    /// Type of a container holding the database's keys
+    using key_set_type = std::vector<key_type>;
 
     /// Read-only reference to a key. Alias for `const KeyType&`
     using const_key_reference = const key_type&;
@@ -65,6 +69,8 @@ public:
 
     /// No-op, no-throw polymorphic default dtor
     virtual ~DatabaseAPI() noexcept = default;
+
+    key_set_type keys() const { return keys_(); }
 
     /** @brief Public API for determining if a database contains a key.
      *
@@ -220,6 +226,18 @@ public:
     void dump() { dump_(); }
 
 protected:
+    /** @brief Hook for derived class to implement keys.
+     *
+     *  The derived class is responsible for overriding this method with a
+     *  definition consistent with the description of DatabaseAPI::keys.
+     *
+     *  @return A container with this database's keys
+     *
+     *  @throw std::bad_alloc if there is a problem creating the return. Strong
+     *         throw guarantee.
+     */
+    virtual key_set_type keys_() const { throw std::runtime_error("NYI"); }
+
     /** @brief Hook for derived class to implement count.
      *
      *  The derived class is responsible for overriding this method with a

--- a/src/pluginplay/cache/database/key_injector.hpp
+++ b/src/pluginplay/cache/database/key_injector.hpp
@@ -44,6 +44,9 @@ public:
     /// Read-only reference to a key, typedef of const KeyType&
     using typename base_type::const_key_reference;
 
+    /// Ultimately a typedef of DatabaseAPI::key_set_type
+    using typename base_type::key_set_type;
+
     /// Type of this database's values
     using typename base_type::mapped_type;
 
@@ -78,6 +81,9 @@ public:
                 sub_db_pointer sub_db);
 
 protected:
+    /// calls m_db_->keys() and then removes the injected key
+    key_set_type keys_() const override;
+
     /// injects into key, then calls m_db_->count()
     bool count_(const_key_reference key) const noexcept override;
 

--- a/src/pluginplay/cache/database/key_injector.ipp
+++ b/src/pluginplay/cache/database/key_injector.ipp
@@ -17,6 +17,13 @@ KEY_INJECTOR::KeyInjector(key_key_type key_to_inject,
 }
 
 TPARAMS
+typename KEY_INJECTOR::key_set_type KEY_INJECTOR::keys_() const {
+    auto rv = m_db_->keys();
+    for(auto& key : rv) key.erase(m_key_to_inject_);
+    return rv;
+}
+
+TPARAMS
 bool KEY_INJECTOR::count_(const_key_reference key) const noexcept {
     // This actually can throw if there's not enough memory
     try {

--- a/src/pluginplay/cache/database/key_proxy_mapper.hpp
+++ b/src/pluginplay/cache/database/key_proxy_mapper.hpp
@@ -24,6 +24,9 @@ public:
     /// Type of the keys, typedef of KeyType
     using typename base_type::key_type;
 
+    /// Ultimately typedef of DatabaseAPI::key_set_type
+    using typename base_type::key_set_type;
+
     /// Read-only reference to a key, typedef of const KeyType&
     using typename base_type::const_key_reference;
 
@@ -60,6 +63,9 @@ public:
     KeyProxyMapper(proxy_map_maker_pointer proxy_mapper, sub_db_pointer sub_db);
 
 protected:
+    /// Returns the keys in the wrapped proxy_mapper
+    key_set_type keys_() const override;
+
     /// Makes sure key is in proxy_mapper, if so then check sub_db
     bool count_(const_key_reference key) const noexcept override;
 

--- a/src/pluginplay/cache/database/key_proxy_mapper.ipp
+++ b/src/pluginplay/cache/database/key_proxy_mapper.ipp
@@ -13,6 +13,11 @@ KEY_PROXY_MAPPER::KeyProxyMapper(proxy_map_maker_pointer proxy_mapper,
 }
 
 TPARAMS
+typename KEY_PROXY_MAPPER::key_set_type KEY_PROXY_MAPPER::keys_() const {
+    return m_proxy_mapper_->keys();
+}
+
+TPARAMS
 bool KEY_PROXY_MAPPER::count_(const_key_reference key) const noexcept {
     // Each part of key needs to be in proxy_mapper or it can't be in sub_db
     if(!m_proxy_mapper_->count(key)) return false;

--- a/src/pluginplay/cache/database/native.hpp
+++ b/src/pluginplay/cache/database/native.hpp
@@ -29,17 +29,20 @@ public:
     using map_type = std::map<KeyType, ValueType>;
 
     /// Type of the keys to this database, typedef of KeyType
-    using key_type = typename base_type::key_type;
+    using typename base_type::key_type;
+
+    /// Ultimately typedef of DatabaseAPI::key_set_type
+    using typename base_type::key_set_type;
 
     /// Type of a read-only reference to a key, typedef of const KeyType&
-    using const_key_reference = typename base_type::const_key_reference;
+    using typename base_type::const_key_reference;
 
     /// Type of the mapped values, typedef of ValueType
-    using mapped_type = typename base_type::mapped_type;
+    using typename base_type::mapped_type;
 
     /// Type of an object holding a read-only reference to a value, typedef of
     /// ConstValue<mapped_type>
-    using const_mapped_reference = typename base_type::const_mapped_reference;
+    using typename base_type::const_mapped_reference;
 
     /// Type of DatabaseAPI that can be used for backup
     using backup_db_type = DatabaseAPI<key_type, mapped_type>;
@@ -83,6 +86,9 @@ public:
     const auto& map() const { return m_map_; }
 
 protected:
+    /// Puts keys in wrapped map into a key_set_type and returns it
+    key_set_type keys_() const override;
+
     /// Calls count on the wrapped map
     bool count_(const_key_reference key) const noexcept override;
 

--- a/src/pluginplay/cache/database/native.ipp
+++ b/src/pluginplay/cache/database/native.ipp
@@ -14,6 +14,13 @@ NATIVE::Native(backup_db_pointer backup) :
   Native(map_type{}, std::move(backup)) {}
 
 TPARAMS
+typename NATIVE::key_set_type NATIVE::keys_() const {
+    key_set_type rv;
+    for(const auto& [k, _] : m_map_) rv.push_back(k);
+    return rv;
+}
+
+TPARAMS
 bool NATIVE::count_(const_key_reference key) const noexcept {
     return m_map_.count(key);
 }

--- a/src/pluginplay/cache/database/serialized.hpp
+++ b/src/pluginplay/cache/database/serialized.hpp
@@ -42,6 +42,9 @@ public:
     /// Typedef of KeyType
     using typename base_type::key_type;
 
+    /// Ultimately a typedef of DatabaseAPI::key_set_type
+    using typename base_type::key_set_type;
+
     /// Typedef of const key_type&
     using typename base_type::const_key_reference;
 
@@ -68,6 +71,9 @@ public:
     Serialized(sub_db_pointer p) : m_db_(std::move(p)) {}
 
 protected:
+    /// returns a container with the deserialized keys
+    key_set_type keys_() const override;
+
     /// Checks if wrapped db has serialized @p key
     bool count_(const_key_reference key) const noexcept override;
 

--- a/src/pluginplay/cache/database/serialized.ipp
+++ b/src/pluginplay/cache/database/serialized.ipp
@@ -6,6 +6,13 @@ namespace pluginplay::cache::database {
 #define SERIALIZED Serialized<KeyType, ValueType>
 
 TPARAMS
+typename SERIALIZED::key_set_type SERIALIZED::keys_() const {
+    key_set_type rv;
+    for(const auto& k : m_db_->keys()) rv.push_back(deserialize_<key_type>(k));
+    return rv;
+}
+
+TPARAMS
 bool SERIALIZED::count_(const_key_reference key) const noexcept {
     try {
         return m_db_->count(serialize_(key));

--- a/src/pluginplay/cache/database/transposer.hpp
+++ b/src/pluginplay/cache/database/transposer.hpp
@@ -41,6 +41,9 @@ public:
     /// Type of the database's keys, typedef of KeyType
     using typename base_type::key_type;
 
+    /// Ultimately a typedef of DatabaseAPI::key_set_type
+    using typename base_type::key_set_type;
+
     /// Type of a read-only reference to a key, typedef of const KeyType&
     using typename base_type::const_key_reference;
 
@@ -77,6 +80,9 @@ public:
     explicit Transposer(wrapped_db_pointer p);
 
 protected:
+    /// Returns a copy of m_keys_
+    key_set_type keys_() const override;
+
     /// Loops over m_keys_ looking for a "key" whose value is @p key
     bool count_(const_key_reference key) const noexcept override;
 

--- a/src/pluginplay/cache/database/transposer.ipp
+++ b/src/pluginplay/cache/database/transposer.ipp
@@ -11,6 +11,13 @@ TRANSPOSER::Transposer(wrapped_db_pointer p) : m_db_(std::move(p)) {
 }
 
 TPARAMS
+typename TRANSPOSER::key_set_type TRANSPOSER::keys_() const {
+    key_set_type rv;
+    for(const auto& val : m_keys_) rv.push_back(m_db_->at(val).get());
+    return rv;
+}
+
+TPARAMS
 bool TRANSPOSER::count_(const_key_reference key) const noexcept {
     for(const auto& val : m_keys_)
         if(m_db_->at(val).get() == key) return true;

--- a/src/pluginplay/cache/database/type_eraser.hpp
+++ b/src/pluginplay/cache/database/type_eraser.hpp
@@ -57,6 +57,9 @@ public:
     /// Type of an object holding a read-only reference
     using typename base_type::const_mapped_reference;
 
+    /// Ultimately a typedef of DatabaseAPI::key_set_type
+    using typename base_type::key_set_type;
+
     /// Type used for type-erasure, typedef of any::AnyField
     using any_type = any::AnyField;
 
@@ -80,6 +83,9 @@ public:
     explicit TypeEraser(wrapped_mapper_pointer db);
 
 public:
+    /// un-type-erases keys from m_db_->keys()
+    key_set_type keys_() const override;
+
     /// type-erases key, then calls m_db_->count
     bool count_(const_key_reference key) const noexcept override;
 

--- a/src/pluginplay/cache/database/type_eraser.ipp
+++ b/src/pluginplay/cache/database/type_eraser.ipp
@@ -12,6 +12,14 @@ TYPE_ERASER::TypeEraser(wrapped_mapper_pointer db) : m_db_(db) {
 }
 
 TPARAMS
+typename TYPE_ERASER::key_set_type TYPE_ERASER::keys_() const {
+    key_set_type rv;
+    for(const auto& key : m_db_->keys())
+        rv.push_back(any::any_cast<key_type>(key));
+    return rv;
+}
+
+TPARAMS
 bool TYPE_ERASER::count_(const_key_reference key) const noexcept {
     return m_db_->count(wrap_(key));
 }

--- a/src/pluginplay/cache/database/value_proxy_mapper.hpp
+++ b/src/pluginplay/cache/database/value_proxy_mapper.hpp
@@ -34,6 +34,9 @@ public:
     /// Type of an object holding a read-only reference to a value
     using typename base_type::const_mapped_reference;
 
+    /// Ultimately a typedef of DatabaseAPI::key_set_type
+    using typename base_type::key_set_type;
+
     /// Type the ProxyMapMaker used for assigning proxies
     using proxy_map_maker = ProxyMapMaker<mapped_type>;
 
@@ -62,6 +65,9 @@ public:
                      sub_db_pointer sub_db);
 
 protected:
+    /// Just calls keys() on the wrapped db
+    key_set_type keys_() const override { return m_sub_db_->keys(); }
+
     /// Makes sure key is in proxy_mapper, if so then check sub_db
     bool count_(const_key_reference key) const noexcept override;
 

--- a/src/pluginplay/cache/proxy_map_maker.hpp
+++ b/src/pluginplay/cache/proxy_map_maker.hpp
@@ -41,12 +41,14 @@ public:
     /// Type of the keys, typedef of KeyType
     using key_type = KeyType;
 
+    /// Ultimately a typedef of DatabaseAPI<key_value_type, ...>::key_set_type
+    using key_set_type = std::vector<key_type>;
+
     /// Read-only reference to a key, typedef of const KeyType&
     using const_key_reference = const key_type&;
 
     /// Type of this database's values, typedef of ValueType
     using mapped_type = std::map<key_key_type, uuid_type, key_key_compare>;
-    ;
 
     /// Type of a read-only reference to a proxy map
     using const_mapped_reference = const mapped_type&;
@@ -69,6 +71,15 @@ public:
      *                            guarantee.
      */
     explicit ProxyMapMaker(proxy_mapper_pointer db);
+
+    /** @brief Returns the set of objects which have been proxied.
+     *
+     *  This function returns the set of keys used as inputs, not the proxied
+     *  versions (which are the values from the perspective of this class).
+     *
+     *  @return The set of objects which have been proxied.
+     */
+    key_set_type keys() const;
 
     /** @brief Determines if all the values in @p key are in the wrapped
      *         database.

--- a/src/pluginplay/cache/proxy_map_maker.ipp
+++ b/src/pluginplay/cache/proxy_map_maker.ipp
@@ -12,7 +12,13 @@ PROXY_MAP_MAKER::ProxyMapMaker(proxy_mapper_pointer db) : m_db_(std::move(db)) {
 }
 
 TPARAMS
-bool PROXY_MAP_MAKER::count(const_key_reference key) const {
+typename PROXY_MAP_MAKER::key_set_type PROXY_MAP_MAKER::keys() const {
+    key_set_type rv;
+    for(const auto& [_, v] : m_buffer_) rv.push_back(v);
+    return rv;
+}
+
+TPARAMS bool PROXY_MAP_MAKER::count(const_key_reference key) const {
     for(const auto& [_, v] : key) {
         if(!m_db_->count(v)) return false;
     }

--- a/src/pluginplay/cache/uuid_mapper.hpp
+++ b/src/pluginplay/cache/uuid_mapper.hpp
@@ -72,6 +72,16 @@ public:
      */
     void insert(key_type key);
 
+    /** @brief Returns the set of objects which have been proxied.
+     *
+     *  N.B. this operation should only be used for debugging as it will copy
+     *  each key into the returned object.
+     *
+     *  @return A container with copies of each key.
+     *
+     *  @throw std::bad_alloc if there is a problem allocating the return.
+     *         Strong throw guarantee.
+     */
     key_set_type keys() const { return m_db_->keys(); }
 
     /// Just calls m_db_->count(key)

--- a/src/pluginplay/cache/uuid_mapper.hpp
+++ b/src/pluginplay/cache/uuid_mapper.hpp
@@ -35,6 +35,9 @@ public:
     /// Type of a pointer to the database storing the object-to-UUID relation
     using db_pointer = std::unique_ptr<db_type>;
 
+    /// Type of a container holding keys
+    using key_set_type = typename db_type::key_set_type;
+
     /** @brief Creates a new UUID instance which stores the UUID mapping in the
      *         provided db
      *
@@ -68,6 +71,8 @@ public:
      *         gurantee.
      */
     void insert(key_type key);
+
+    key_set_type keys() const { return m_db_->keys(); }
 
     /// Just calls m_db_->count(key)
     bool count(const_key_reference key) const noexcept;

--- a/tests/pluginplay/cache/database/key_injector.cpp
+++ b/tests/pluginplay/cache/database/key_injector.cpp
@@ -14,8 +14,9 @@ TEMPLATE_LIST_TEST_CASE("KeyInjector", "", test_types) {
     using key_type       = std::map<key_key_type, key_value_type>;
     using value_type     = key_type;
 
-    using db_type     = KeyInjector<key_type, value_type>;
-    using sub_db_type = Native<key_type, value_type>;
+    using db_type      = KeyInjector<key_type, value_type>;
+    using sub_db_type  = Native<key_type, value_type>;
+    using key_set_type = typename db_type::key_set_type;
 
     auto sub_sub_db = std::make_unique<sub_db_type>();
     auto psub       = sub_sub_db.get();
@@ -37,6 +38,8 @@ TEMPLATE_LIST_TEST_CASE("KeyInjector", "", test_types) {
         REQUIRE_THROWS_AS(db_type(defaulted_key, defaulted_value, nullptr),
                           std::runtime_error);
     }
+
+    SECTION("keys") { REQUIRE(db.keys() == key_set_type{key0}); }
 
     SECTION("count") {
         REQUIRE(db.count(key0));

--- a/tests/pluginplay/cache/database/key_proxy_mapper.cpp
+++ b/tests/pluginplay/cache/database/key_proxy_mapper.cpp
@@ -10,9 +10,10 @@ using namespace testing;
 TEMPLATE_LIST_TEST_CASE("KeyProxyMapper", "", testing::test_types) {
     // Type of the keys, values, and resulting KeyProxyMapper we're testing
     // N.B. double not in test_types so value_type != key_type
-    using key_type    = std::map<std::string, TestType>;
-    using value_type  = std::map<std::string, double>;
-    using mapper_type = KeyProxyMapper<key_type, value_type>;
+    using key_type     = std::map<std::string, TestType>;
+    using value_type   = std::map<std::string, double>;
+    using mapper_type  = KeyProxyMapper<key_type, value_type>;
+    using key_set_type = typename mapper_type::key_set_type;
 
     // ProxyMappers need to sub objects a ProxyMapMaker and a sub database
     // First we figure out the ProxyMapMaker type and what's being proxied
@@ -55,6 +56,8 @@ TEMPLATE_LIST_TEST_CASE("KeyProxyMapper", "", testing::test_types) {
     SECTION("CTor") {
         REQUIRE_THROWS_AS(mapper_type(nullptr, nullptr), std::runtime_error);
     }
+
+    SECTION("keys") { REQUIRE(db.keys() == key_set_type{key0}); }
 
     SECTION("count") {
         REQUIRE(db.count(key0));

--- a/tests/pluginplay/cache/database/native.cpp
+++ b/tests/pluginplay/cache/database/native.cpp
@@ -12,7 +12,8 @@ TEMPLATE_LIST_TEST_CASE("Map", "", test_types) {
     using key_type    = std::tuple_element_t<0, value_type>;
     using mapped_type = std::tuple_element_t<1, value_type>;
 
-    using map_type = Native<key_type, mapped_type>;
+    using map_type     = Native<key_type, mapped_type>;
+    using key_set_type = typename map_type::key_set_type;
 
     key_type default_key{};
     mapped_type default_value{};
@@ -30,6 +31,12 @@ TEMPLATE_LIST_TEST_CASE("Map", "", test_types) {
         REQUIRE(defaulted.map() == default_map);
         REQUIRE(has_val.map() == val);
         REQUIRE(has_backup.map() == val);
+    }
+
+    SECTION("keys") {
+        REQUIRE(defaulted.keys() == key_set_type{});
+        REQUIRE(has_val.keys() == key_set_type{default_key});
+        REQUIRE(has_backup.keys() == key_set_type{default_key});
     }
 
     SECTION("Count") {

--- a/tests/pluginplay/cache/database/serialized.cpp
+++ b/tests/pluginplay/cache/database/serialized.cpp
@@ -33,6 +33,9 @@ TEMPLATE_LIST_TEST_CASE("Serialized", "", test_types) {
     // Determine the specialization of Serialized being tested
     using serialized_type = Serialized<key_type, mapped_type>;
 
+    // Determine the type returned by keys()
+    using key_set_type = typename serialized_type::key_set_type;
+
     // Work out the type of the wrapped database
     using binary_type = typename serialized_type::binary_type;
     using sub_db_type = Native<binary_type, binary_type>;
@@ -50,6 +53,8 @@ TEMPLATE_LIST_TEST_CASE("Serialized", "", test_types) {
     serialized_type smap(std::move(pdb));
 
     smap.insert(key1, value1);
+
+    SECTION("keys") { REQUIRE(smap.keys() == key_set_type{key1}); }
 
     SECTION("count") {
         REQUIRE_FALSE(smap.count(key0));

--- a/tests/pluginplay/cache/database/transposer.cpp
+++ b/tests/pluginplay/cache/database/transposer.cpp
@@ -18,6 +18,8 @@ TEMPLATE_LIST_TEST_CASE("Transposer", "", test_types) {
     using backup_db_type  = Native<mapped_type, key_type>;
     using db_type         = Transposer<key_type, mapped_type>;
 
+    using key_set_type = typename db_type::key_set_type;
+
     key_type key0{};
     auto key1 = testing::lexical_cast<key_type>("42");
     mapped_type val0{};
@@ -34,6 +36,8 @@ TEMPLATE_LIST_TEST_CASE("Transposer", "", test_types) {
         using ptr_type = typename db_type::wrapped_db_pointer;
         REQUIRE_THROWS_AS(db_type(ptr_type{}), std::runtime_error);
     }
+
+    SECTION("keys") { REQUIRE(has_val.keys() == key_set_type{key0}); }
 
     SECTION("Count") {
         REQUIRE(has_val.count(key0));

--- a/tests/pluginplay/cache/database/type_eraser.cpp
+++ b/tests/pluginplay/cache/database/type_eraser.cpp
@@ -12,6 +12,8 @@ TEMPLATE_LIST_TEST_CASE("TypeEraser", "", test_types) {
     using value_type = std::string;
     using db_type    = TypeEraser<key_type, value_type>;
 
+    using key_set_type = typename db_type::key_set_type;
+
     // The type the DB uses for type-erased stuff
     using any_type = typename db_type::any_type;
 
@@ -43,6 +45,8 @@ TEMPLATE_LIST_TEST_CASE("TypeEraser", "", test_types) {
     SECTION("CTors") {
         REQUIRE_THROWS_AS(db_type(nullptr), std::runtime_error);
     }
+
+    SECTION("keys") { REQUIRE(db.keys() == key_set_type{key0}); }
 
     SECTION("count") {
         REQUIRE(db.count(key0));

--- a/tests/pluginplay/cache/database/value_proxy_mapper.cpp
+++ b/tests/pluginplay/cache/database/value_proxy_mapper.cpp
@@ -10,9 +10,10 @@ using namespace testing;
 TEMPLATE_LIST_TEST_CASE("ValueProxyMapper", "", testing::test_types) {
     // Type of the keys, values, and resulting KeyProxyMapper we're testing
     // N.B. double not in test_types so value_type != key_type
-    using key_type    = std::map<std::string, TestType>;
-    using value_type  = std::map<std::string, double>;
-    using mapper_type = ValueProxyMapper<key_type, value_type>;
+    using key_type     = std::map<std::string, TestType>;
+    using value_type   = std::map<std::string, double>;
+    using mapper_type  = ValueProxyMapper<key_type, value_type>;
+    using key_set_type = typename mapper_type::key_set_type;
 
     // ProxyMappers need to sub objects a ProxyMapMaker and a sub database
     // First we figure out the ProxyMapMaker type and what's being proxied
@@ -55,6 +56,8 @@ TEMPLATE_LIST_TEST_CASE("ValueProxyMapper", "", testing::test_types) {
     SECTION("CTor") {
         REQUIRE_THROWS_AS(mapper_type(nullptr, nullptr), std::runtime_error);
     }
+
+    SECTION("keys") { REQUIRE(db.keys() == key_set_type{key0}); }
 
     SECTION("count") {
         REQUIRE(db.count(key0));

--- a/tests/pluginplay/cache/proxy_map_maker.cpp
+++ b/tests/pluginplay/cache/proxy_map_maker.cpp
@@ -13,6 +13,7 @@ TEMPLATE_LIST_TEST_CASE("ProxyMapMaker", "", testing::test_types) {
     auto [psub_sub, psub, puuid_db, db] = make_proxy_map_maker<key_type>();
     using db_type                       = decltype(db);
     using value_type                    = typename db_type::mapped_type;
+    using key_set_type                  = typename db_type::key_set_type;
 
     TestType default_value{};
     key_type key0{{"world", default_value}};
@@ -25,6 +26,8 @@ TEMPLATE_LIST_TEST_CASE("ProxyMapMaker", "", testing::test_types) {
     value_type value0{{"world", uuid}};
 
     SECTION("CTor") { REQUIRE_THROWS_AS(db_type(nullptr), std::runtime_error); }
+
+    SECTION("keys") { REQUIRE(db.keys() == key_set_type{key0}); }
 
     SECTION("Count") {
         REQUIRE(db.count(key0));

--- a/tests/pluginplay/cache/uuid_mapper.cpp
+++ b/tests/pluginplay/cache/uuid_mapper.cpp
@@ -14,6 +14,7 @@ TEMPLATE_LIST_TEST_CASE("UUIDMapper", "", testing::test_types) {
     using key_type     = TestType;
     using uuid_db_type = UUIDMapper<key_type>;
     using uuid_type    = typename uuid_db_type::mapped_type;
+    using key_set_type = typename uuid_db_type::key_set_type;
 
     auto [pinner, db] = testing::make_nested_native<key_type, uuid_type>();
 
@@ -26,6 +27,8 @@ TEMPLATE_LIST_TEST_CASE("UUIDMapper", "", testing::test_types) {
     SECTION("CTor") {
         REQUIRE_THROWS_AS(uuid_db_type(nullptr), std::runtime_error);
     }
+
+    SECTION("keys") { REQUIRE(uuid_db.keys() == key_set_type{key0}); }
 
     SECTION("count") {
         REQUIRE(uuid_db.count(key0));


### PR DESCRIPTION
This PR adds functionality to iterate over the keys in a database. At the moment this would be a very expensive operation if it was used in the wild (for some layers of the cache you would end up un-proxying the same object multiple times). `keys` is only exposed through the `DatabaseAPI` (which itself is not exposed to users) which prevents inadvertent use. I primarily envision this functionality being used for debugging and unit testing the cache.