### PR TITLE
Delete utilities table

### DIFF
--- a/src/pluginplay/printing/detail_/print_inputs.cpp
+++ b/src/pluginplay/printing/detail_/print_inputs.cpp
@@ -17,10 +17,7 @@
 #include "fort_custom_styles.hpp"
 #include "print_inputs.hpp"
 #include <fort.hpp>
-#include <utilities/printing/table.hpp>
 namespace pluginplay::printing::detail_ {
-
-using Table = utilities::printing::Table;
 
 reSTPrinter& input_desc(reSTPrinter& p) {
     p << "This section details the full list of inputs that the module accepts."

--- a/src/pluginplay/printing/detail_/print_results.cpp
+++ b/src/pluginplay/printing/detail_/print_results.cpp
@@ -18,10 +18,7 @@
 #include "print_results.hpp"
 #include <fort.hpp>
 #include <utilities/printing/demangler.hpp>
-#include <utilities/printing/table.hpp>
 namespace pluginplay::printing::detail_ {
-
-using Table = utilities::printing::Table;
 
 reSTPrinter& result_desc(reSTPrinter& p) {
     p << "This section tabulates the full list of results that the module "

--- a/src/pluginplay/printing/detail_/print_submodules.cpp
+++ b/src/pluginplay/printing/detail_/print_submodules.cpp
@@ -18,11 +18,8 @@
 #include "print_submodules.hpp"
 #include <fort.hpp>
 #include <utilities/printing/demangler.hpp>
-#include <utilities/printing/table.hpp>
 
 namespace pluginplay::printing::detail_ {
-
-using Table = utilities::printing::Table;
 
 reSTPrinter& submod_desc(reSTPrinter& p) {
     p << "This section details the full list of submodules that the module "

--- a/tests/pluginplay/cache/database/rocksdb/rocksdb.cpp
+++ b/tests/pluginplay/cache/database/rocksdb/rocksdb.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 #include <catch2/catch.hpp>
 #include <filesystem>
 #include <pluginplay/cache/database/rocksdb/rocksdb.hpp>


### PR DESCRIPTION
Table class was deprecated earlier in favor of [libfort](https://github.com/seleznevae/libfort). This PR removes the obsolete dependency of `utilities/printing/table.hpp` as mentioned [here](https://github.com/NWChemEx-Project/Utilities/issues/111).