### PR TITLE
fix typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(nwx_versions)
 
 ### Options ###
 option(BUILD_TESTING "Should we build the tests?" OFF)
-option(BUILD_PYBIND11_PYBINDIGS "Use pybind11 to build Python3 bindings?" OFF)
+option(BUILD_PYBIND11_PYBINDINGS "Use pybind11 to build Python3 bindings?" OFF)
 option(BUILD_CPPYY_PYBINDINGS "Use Cppyy to build Python3 bindings?" OFF)
 option(BUILD_ROCKSDB "Should we build the RocksDB backend?" OFF)
 


### PR DESCRIPTION
I discovered that I missed an "N" in line that sets the default option for `BUILD_PYBIND11_PYBINDINGS`. Since an unset variable defaults to false (which is also the present default for `BUILD_PYBIND11_PYBINDINGS`, this did not actually affect correctness.

This is r2g.