### PR TITLE
Fixes #309

### DIFF
--- a/src/python/export_module_manager.cpp
+++ b/src/python/export_module_manager.cpp
@@ -34,9 +34,11 @@ void export_module_manager(py_module_reference m) {
       .def(pybind11::init<>())
       .def("count", &ModuleManager::count)
       .def("size", &ModuleManager::size)
-      .def("add_module",
-           [](ModuleManager& mm, std::string key,
-              std::shared_ptr<PyModuleBase> p) { mm.add_module(key, p); })
+      .def(
+        "add_module",
+        [](ModuleManager& mm, std::string key,
+           std::shared_ptr<PyModuleBase> p) { mm.add_module(key, p); },
+        pybind11::keep_alive<1, 3>())
       .def("at", static_cast<at_fxn>(&ModuleManager::at))
       .def("copy_module", &ModuleManager::copy_module)
       .def("erase", &ModuleManager::erase)

--- a/tests/python/unit_tests/test_module_manager.py
+++ b/tests/python/unit_tests/test_module_manager.py
@@ -16,6 +16,17 @@ import pluginplay as pp
 import py_test_pluginplay as test_pp
 import unittest
 
+class APythonModule(pp.ModuleBase):
+    def __init__(self):
+        pp.ModuleBase.__init__(self)
+        self.satisfies_property_type(test_pp.OneInOneOut())
+
+    def run_(self, inputs, submods):
+        pt = test_pp.OneInOneOut()
+        i0, = pt.unwrap_inputs(inputs)
+        rv = self.results()
+        return pt.wrap_results(rv, i0)
+
 class TestModuleManager(unittest.TestCase):
     def test_count(self):
         # Defaulted is always false
@@ -167,6 +178,21 @@ class TestModuleManager(unittest.TestCase):
 
         # Can actually run the function
         rv = fxn2test(pt, mod_key, 1)
+        self.assertEqual(rv, 1)
+
+
+    def test_pluginplay_309(self):
+        ''' This regression test is in response to issue #309.
+
+            The problem behind #309 was that we weren't keeping the Python part
+            of modules written in Python alive when they were added to the
+            ModuleManager. Without the fix to #309 this test should fail.
+        '''
+
+        mm = pp.ModuleManager()
+        mm.add_module('Issue 309', APythonModule())
+        pt = test_pp.OneInOneOut()
+        rv = mm.run_as(pt, 'Issue 309', 1)
         self.assertEqual(rv, 1)
 
 


### PR DESCRIPTION
As the title says, this PR should fix #309. The problem was a lifetime issue. The existing unit test works because it keeps the Python part of the module alive by assigning it to the testing structure; however, the more common scenario is what is shown in #309 where we do something like `mm.add_module('key', MyPythonModule())`. Without `keep_alive` Python's garbage collector throws out the Python part of the object after the call, which is why it can't resolve the `run_` overload.

~Edit: I put it back to a draft so I can add a regression test. This will be r2g once I've confirmed the regression test works locally.~