### PR TITLE
More detailed error messages for `Module::change_input` and `Module::change_submod`

### DIFF
--- a/include/pluginplay/module/module_class.hpp
+++ b/include/pluginplay/module/module_class.hpp
@@ -747,6 +747,14 @@ bool Module::ready() const {
 template<typename T>
 void Module::change_input(const type::key& key, T&& value) {
     assert_not_locked_();
+    if(!inputs().count(key)) {
+        std::string msg = " does not have input \"" + key + "\"";
+        if(has_name())
+            msg = "Module \"" + get_name() + "\"" + msg;
+        else
+            msg = "Unnamed module" + msg;
+        throw std::out_of_range(msg);
+    }
     get_input_(key).change(std::forward<T>(value));
 }
 

--- a/include/pluginplay/module_manager/module_manager_class.hpp
+++ b/include/pluginplay/module_manager/module_manager_class.hpp
@@ -100,6 +100,13 @@ public:
      */
     type::size size() const noexcept;
 
+    /** @brief Used to add a new module to the list
+     *
+     * @tparam ModuleType The type of the module being added. This type must be
+     *                    constructible with no arguments and must inherit from
+     *                    ModuleBase.
+     * @param module_key
+     */
     template<typename ModuleType>
     void add_module(type::key module_key);
 
@@ -108,7 +115,6 @@ public:
      * @param module_key
      * @param base
      */
-
     void add_module(type::key module_key, module_base_ptr base);
 
     ///@{

--- a/src/pluginplay/module/module.cpp
+++ b/src/pluginplay/module/module.cpp
@@ -78,6 +78,14 @@ void Module::lock() { m_pimpl_->lock(); }
 
 void Module::change_submod(type::key key, std::shared_ptr<Module> new_module) {
     assert_not_locked_();
+    if(!submods().count(key)) {
+        std::string msg = " does not have submodule \"" + key + "\"";
+        if(has_name())
+            msg = "Module \"" + get_name() + "\"" + msg;
+        else
+            msg = "Unnamed module" + msg;
+        throw std::out_of_range(msg);
+    }
     m_pimpl_->submods().at(key).change(new_module);
 }
 

--- a/tests/cxx/unit_tests/pluginplay/catch.hpp
+++ b/tests/cxx/unit_tests/pluginplay/catch.hpp
@@ -18,3 +18,4 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>

--- a/tests/cxx/unit_tests/pluginplay/module/module_class.cpp
+++ b/tests/cxx/unit_tests/pluginplay/module/module_class.cpp
@@ -290,7 +290,12 @@ TEST_CASE("Module : change_input") {
     }
     SECTION("Throws if input does not exist") {
         auto mod = make_module<NotReadyModule>();
-        REQUIRE_THROWS_AS(mod->change_input("Not a key", 3), std::out_of_range);
+        REQUIRE_THROWS_WITH(mod->change_input("Not a key", 3),
+                            "Unnamed module does not have input \"Not a key\"");
+        mod->set_name("Test");
+        REQUIRE_THROWS_WITH(
+          mod->change_input("Not a key", 3),
+          "Module \"Test\" does not have input \"Not a key\"");
     }
     SECTION("Throws if value is wrong type") {
         auto mod = make_module<NotReadyModule>();
@@ -316,8 +321,13 @@ TEST_CASE("Module : change_submod") {
         REQUIRE_THROWS_AS(p.change_submod(key, value), std::runtime_error);
     }
     SECTION("Throws if request does not exist") {
-        REQUIRE_THROWS_AS(mod->change_submod("Not a key", value),
-                          std::out_of_range);
+        REQUIRE_THROWS_WITH(
+          mod->change_submod("Not a key", value),
+          "Unnamed module does not have submodule \"Not a key\"");
+        mod->set_name("Test");
+        REQUIRE_THROWS_WITH(
+          mod->change_submod("Not a key", value),
+          "Module \"Test\" does not have submodule \"Not a key\"");
     }
     SECTION("Throws if value is wrong type") {
         auto mod2 = make_module<NotReadyModule>();


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
`Module::change_input` or `Module::change_submod` throw generic `std::out_of_range` exceptions when they are called with improper key values. These changes try to provide more context for these errors by identifying the key that caused the failure, as well as the module name is available.