### PR TITLE
Adds the ability to create Python-only property types

### DIFF
--- a/docs/source/developer/design/property_type.rst
+++ b/docs/source/developer/design/property_type.rst
@@ -103,7 +103,7 @@ Python Property Types
 
 Property types defined in C++ can be used in Python so long as the types in the
 interface are registered with pybind11. Some users will want to
-define their property types in Python though. In such case sthe inputs/results
+define their property types in Python though. In such cases the inputs/results
 are Python types and will not be visible to C++ (without some sort of
 registration system).
 

--- a/docs/source/developer/design/property_type.rst
+++ b/docs/source/developer/design/property_type.rst
@@ -101,9 +101,11 @@ objects to define as simple of an :ref:`api` as possible.
 Python Property Types
 =====================
 
-Property types defined in C++ can be used in Python too. Some users will want to
-define their property types in Python so that the inputs/results are Python 
-types. 
+Property types defined in C++ can be used in Python so long as the types in the
+interface are registered with pybind11. Some users will want to
+define their property types in Python though. In such case sthe inputs/results
+are Python types and will not be visible to C++ (without some sort of
+registration system).
 
 We propose to develop a class ``PythonOnlyPropertyType`` that defines the base
 API for property types written in Python. Python property types are then
@@ -116,7 +118,7 @@ type API is envisioned as working like:
          def __init__(self):
             super().__init__(self)
             self.satisfies_property_type(MyPythonPropertyType())
-   
+
          def run_(self, inputs, submods):
             [inp0, inp1, inp2] = MyPythonPropertyType.unwrap_inputs(inputs)
 
@@ -140,7 +142,7 @@ The definition of the property type would look like:
             self.declare_results("res2").set_description("Result 2 description")
 
 The property type would be responsible for knowing how many inputs/results there
-are and the descriptions of each. Consistent with typical Python usage, the 
+are and the descriptions of each. Consistent with typical Python usage, the
 property type should allow duck typing. The latter means that the property type
 can not be used from C++ without some sort of type registration system.
 

--- a/docs/source/developer/design/property_type.rst
+++ b/docs/source/developer/design/property_type.rst
@@ -98,6 +98,53 @@ responsible for storing not only the types of the inputs, but also the default
 values, descriptions, etc. It is the responsibility of the ``FieldTuple``
 objects to define as simple of an :ref:`api` as possible.
 
+Python Property Types
+=====================
+
+Property types defined in C++ can be used in Python too. Some users will want to
+define their property types in Python so that the inputs/results are Python 
+types. 
+
+We propose to develop a class ``PythonOnlyPropertyType`` that defines the base
+API for property types written in Python. Python property types are then
+implemented by deriving from ``PythonOnlyPropertyType``. Use of the property
+type API is envisioned as working like:
+
+.. code-block:: python
+
+   class MyPythonModule(pp.ModuleBase):
+         def __init__(self):
+            super().__init__(self)
+            self.satisfies_property_type(MyPythonPropertyType())
+   
+         def run_(self, inputs, submods):
+            [inp0, inp1, inp2] = MyPythonPropertyType.unwrap_inputs(inputs)
+
+            # Do work with inp0, inp1, inp2
+
+            rv = self.results()
+            return MyPythonPropertyType.wrap_results(rv, res0, res1, res2)
+
+The definition of the property type would look like:
+
+.. code-block:: python
+
+   class MyPythonPropertyType(pp.PythonOnlyPropertyType):
+         def __init__(self):
+            self.declare_inputs("inp0").set_description("Input 0 description")
+            self.declare_inputs("inp1").set_description("Input 1 description")
+            self.declare_inputs("inp2").set_description("Input 2 description")
+
+            self.declare_results("res0").set_description("Result 0 description")
+            self.declare_results("res1").set_description("Result 1 description")
+            self.declare_results("res2").set_description("Result 2 description")
+
+The property type would be responsible for knowing how many inputs/results there
+are and the descriptions of each. Consistent with typical Python usage, the 
+property type should allow duck typing. The latter means that the property type
+can not be used from C++ without some sort of type registration system.
+
+
 Summary
 =======
 

--- a/include/pluginplay/module/module_base.hpp
+++ b/include/pluginplay/module/module_base.hpp
@@ -19,6 +19,7 @@
 #include <parallelzone/runtime/runtime_view.hpp>
 #include <pluginplay/cache/cache.hpp>
 #include <pluginplay/fields/fields.hpp>
+#include <pluginplay/property_type/python_only_property_type.hpp>
 #include <pluginplay/python/python_wrapper.hpp>
 #include <pluginplay/submodule_request.hpp>
 #include <pluginplay/utility/uuid.hpp>
@@ -207,6 +208,24 @@ public:
      */
     const auto& property_types() const noexcept { return m_property_types_; }
 
+    /** @brief Returns the set of Python-only property types this module
+     *         satisfies.
+     *
+     *  Python-only property types (`python::PythonOnlyPropertyType`) don't
+     *  have a distinct C++ RTTI -- every instance shares
+     *  `typeid(python::PythonOnlyPropertyType)` -- so their real identity,
+     *  the `name()` string, is tracked separately from
+     *  ModuleBase::property_types.
+     *
+     *  @return The set of names of Python-only property types that this
+     *          module can be run as.
+     *
+     *  @throw none No throw guarantee.
+     */
+    const auto& python_property_types() const noexcept {
+        return m_python_property_types_;
+    }
+
     /** @brief Returns the RTTI of the derived class.
      *
      *  The type of the derived class is used to index caches. More
@@ -339,6 +358,27 @@ public:
         m_property_types_.insert(std::move(rtti));
         m_inputs_.insert(inputs.begin(), inputs.end());
         m_results_.insert(results.begin(), results.end());
+    }
+
+    /** @brief Specifies that the derived module satisfies the Python-only
+     *         property type @p pt.
+     *
+     *  Merges @p pt's declared inputs/results into this module's inputs and
+     *  results (same as the RTTI-keyed overload above), records the shared
+     *  `typeid(python::PythonOnlyPropertyType)` marker in property_types()
+     *  for visibility, and records @p pt.name() -- the real identity -- in
+     *  python_property_types().
+     *
+     *  @param[in] pt The Python-only property type this module satisfies.
+     *
+     *  @throw std::bad_alloc if there is insufficient memory to add the
+     *                        property type's inputs and results. Weak throw
+     *                        guarantee.
+     */
+    void satisfies_property_type(const python::PythonOnlyPropertyType& pt) {
+        satisfies_property_type(type::rtti(typeid(python::PythonOnlyPropertyType)),
+                                pt.inputs(), pt.results());
+        m_python_property_types_.insert(pt.name());
     }
 
 protected:
@@ -552,6 +592,9 @@ private:
     /// The property types this module satisfies
     std::set<type::rtti> m_property_types_;
 
+    /// The names of the Python-only property types this module satisfies
+    std::set<std::string> m_python_property_types_;
+
     /// The RTTI of the derived class
     type::rtti m_type_;
 
@@ -584,9 +627,10 @@ inline bool ModuleBase::operator==(const ModuleBase& rhs) const noexcept {
     if(has_description() && get_desc() != rhs.get_desc()) return false;
     if(m_citations_ != rhs.m_citations_) return false;
     if(m_is_python_ != rhs.m_is_python_) return false;
-    return std::tie(inputs(), results(), submods(), property_types()) ==
+    return std::tie(inputs(), results(), submods(), property_types(),
+                    python_property_types()) ==
            std::tie(rhs.inputs(), rhs.results(), rhs.submods(),
-                    rhs.property_types());
+                    rhs.property_types(), rhs.python_property_types());
 }
 
 inline bool ModuleBase::operator!=(const ModuleBase& rhs) const noexcept {

--- a/include/pluginplay/module/module_base.hpp
+++ b/include/pluginplay/module/module_base.hpp
@@ -376,8 +376,9 @@ public:
      *                        guarantee.
      */
     void satisfies_property_type(const python::PythonOnlyPropertyType& pt) {
-        satisfies_property_type(type::rtti(typeid(python::PythonOnlyPropertyType)),
-                                pt.inputs(), pt.results());
+        satisfies_property_type(
+          type::rtti(typeid(python::PythonOnlyPropertyType)), pt.inputs(),
+          pt.results());
         m_python_property_types_.insert(pt.name());
     }
 

--- a/include/pluginplay/module/module_class.hpp
+++ b/include/pluginplay/module/module_class.hpp
@@ -17,6 +17,7 @@
 #pragma once
 #include "pluginplay/types.hpp"
 #include <pluginplay/fields/fields.hpp>
+#include <pluginplay/property_type/python_only_property_type.hpp>
 #include <pluginplay/utility/uuid.hpp>
 #include <utilities/containers/case_insensitive_map.hpp>
 
@@ -455,6 +456,23 @@ public:
      */
     const std::set<type::rtti>& property_types() const;
 
+    /** @brief Returns the set of Python-only property types (by name) that
+     *         this module can be run as.
+     *
+     *  Python-only property types (python::PythonOnlyPropertyType) share a
+     *  single RTTI, so unlike property_types() (which is keyed on RTTI),
+     *  this set is keyed on the property type's name() -- see
+     *  ModuleBase::satisfies_property_type(const
+     *  python::PythonOnlyPropertyType&).
+     *
+     * @return The set of Python-only property type names that this module
+     *         satisfies.
+     *
+     * @throw std::runtime_error if this instance does not have an
+     *                           implementation. Strong throw guarantee.
+     */
+    const std::set<std::string>& python_property_types() const;
+
     /** @brief Returns the human-readable description provided by the developer
      *
      *  Developers are encouraged to provide human-readable descriptions of what
@@ -617,6 +635,34 @@ public:
     template<typename property_type, typename... Args>
     auto run_as(Args&&... args);
 
+    /** @brief Runs this module as the provided Python-only property type.
+     *
+     *  Same purpose as the templated run_as above, but for
+     *  python::PythonOnlyPropertyType, whose identity is a name() string
+     *  rather than a compile-time C++ type. @p args is bound positionally,
+     *  in @p pt's declared input order, wrapped opaquely as Python objects;
+     *  the results are unwrapped the same way and returned in @p pt's
+     *  declared result order. Dispatch still funnels through the ordinary
+     *  Module::run(), so memoization and submodule resolution behave exactly
+     *  as they do for C++ property types.
+     *
+     *  @tparam ArgsType The type representing Python's "args" concept
+     *          (expected to be pybind11::args; templated so this header
+     *          stays includable without pybind11 support).
+     *
+     *  @param[in] pt The Python-only property type to run this module as.
+     *  @param[in] args The input values that will be forwarded to the module.
+     *
+     *  @return The unwrapped results, in @p pt's declared result order.
+     *
+     *  @throw std::runtime_error if the module does not satisfy @p pt (by
+     *                            name), or the usual run() failure modes.
+     *                            Strong throw guarantee.
+     */
+    template<typename ArgsType>
+    std::vector<python::PythonWrapper> run_as(
+      const python::PythonOnlyPropertyType& pt, ArgsType&& args);
+
     /** @brief The advanced API for running the module.
      *
      *  This member allows you to set whatever inputs you would like and gives
@@ -720,6 +766,9 @@ private:
     /// Hides the check of the property type
     void check_property_type_(type::rtti prop_type);
 
+    /// Hides the check of a Python-only property type (checked by name)
+    void check_python_property_type_(const std::string& name);
+
     /// The instance that actually does everything for us.
     pimpl_ptr m_pimpl_;
 
@@ -786,6 +835,14 @@ auto Module::run_as(Args&&... args) {
             return rv;
         }
     }
+}
+
+template<typename ArgsType>
+std::vector<python::PythonWrapper> Module::run_as(
+  const python::PythonOnlyPropertyType& pt, ArgsType&& args) {
+    check_python_property_type_(pt.name());
+    auto temp = pt.wrap_inputs(inputs(), std::forward<ArgsType>(args));
+    return pt.unwrap_results(run(temp));
 }
 
 inline void Module::assert_not_locked_() {

--- a/include/pluginplay/property_type/python_only_property_type.hpp
+++ b/include/pluginplay/property_type/python_only_property_type.hpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <pluginplay/fields/fields.hpp>
+#include <pluginplay/python/python_wrapper.hpp>
+#include <pluginplay/types.hpp>
+#include <stdexcept>
+#include <vector>
+
+namespace pluginplay::python {
+
+/** @brief Runtime (non-CRTP) analog of PropertyType<T> for property types
+ *         defined entirely in Python.
+ *
+ *  `PropertyType<DerivedType>` relies on CRTP to give each property type a
+ *  distinct C++ type (and hence a distinct RTTI). That trick doesn't help
+ *  here: every field of a Python-only property type is an opaque Python
+ *  object, so there's nothing for per-field C++ typing to key off, and no
+ *  way to synthesize a new, distinct C++ RTTI from Python at runtime
+ *  (`std::type_index` can only wrap a real `std::type_info` obtained via
+ *  `typeid()`). Consequently a *single* concrete class,
+ * `PythonOnlyPropertyType`,
+ *  represents every Python-only property type; instances differ only in
+ *  their `name()` and declared field keys, which are ordinary runtime data.
+ *
+ *  Because of this, all `PythonOnlyPropertyType` instances share the same
+ *  RTTI (`typeid(PythonOnlyPropertyType)`). Real identity -- used to decide
+ *  whether a module satisfies a *specific* Python-only property type -- is
+ *  the `name()` string, checked via a set separate from the usual
+ *  `ModuleBase`/`Module` RTTI-keyed property type set.
+ *
+ *  Every declared field is stored as a `PythonWrapper`-typed `ModuleInput`/
+ *  `ModuleResult`, so once wrapped, the values flow through PluginPlay's
+ *  ordinary type-erased `Module::run()` pipeline (memoization, submodule
+ *  resolution, etc.) completely unchanged.
+ */
+class PythonOnlyPropertyType {
+public:
+    explicit PythonOnlyPropertyType(std::string name) :
+      m_name_(std::move(name)) {}
+
+    virtual ~PythonOnlyPropertyType() noexcept = default;
+
+    /// The identity of this Python-only property type.
+    const std::string& name() const noexcept { return m_name_; }
+
+    /** @brief Declares a new input field named @p key.
+     *
+     *  Fields are always typed as PythonWrapper (i.e. an opaque Python
+     *  object). The returned reference can be used to chain
+     *  `.set_description(...)`/`.set_default(...)` calls, mirroring
+     *  `ModuleBase::add_input`.
+     */
+    ModuleInput& declare_input(const type::key& key);
+
+    /// Same as declare_input, but for a result field.
+    ModuleResult& declare_result(const type::key& key);
+
+    const type::input_map& inputs() const noexcept { return m_inputs_; }
+
+    const type::result_map& results() const noexcept { return m_results_; }
+
+    /// The order fields were declared in declare_input, used for positional
+    /// wrap_inputs/unwrap_inputs.
+    const std::vector<type::key>& input_order() const noexcept {
+        return m_input_order_;
+    }
+
+    /// The order fields were declared in declare_result, used for positional
+    /// wrap_results/unwrap_results.
+    const std::vector<type::key>& result_order() const noexcept {
+        return m_result_order_;
+    }
+
+    /** @brief Binds @p args, positionally, to @p rv's input fields.
+     *
+     *  @tparam ArgsType Expected to be pybind11::args, but templated (rather
+     *          than including pybind11 directly) so this header stays
+     *          includable without pybind11 support, mirroring
+     *          pluginplay::python::py_wrap_inputs.
+     */
+    template<typename ArgsType>
+    type::input_map wrap_inputs(type::input_map rv, ArgsType&& args) const;
+
+    /// Same as wrap_inputs, but for result fields.
+    template<typename ArgsType>
+    type::result_map wrap_results(type::result_map rv, ArgsType&& args) const;
+
+    /// Unwraps @p im's fields, in declaration order, back into Python objects.
+    std::vector<PythonWrapper> unwrap_inputs(const type::input_map& im) const;
+
+    /// Unwraps @p rm's fields, in declaration order, back into Python objects.
+    std::vector<PythonWrapper> unwrap_results(const type::result_map& rm) const;
+
+private:
+    std::string m_name_;
+    type::input_map m_inputs_;
+    type::result_map m_results_;
+    std::vector<type::key> m_input_order_;
+    std::vector<type::key> m_result_order_;
+};
+
+template<typename ArgsType>
+type::input_map PythonOnlyPropertyType::wrap_inputs(type::input_map rv,
+                                                    ArgsType&& args) const {
+    if(static_cast<std::size_t>(args.size()) != m_input_order_.size())
+        throw std::runtime_error("PythonOnlyPropertyType \"" + m_name_ +
+                                 "\": wrong number of positional inputs");
+    for(std::size_t i = 0; i < m_input_order_.size(); ++i)
+        rv.at(m_input_order_[i]).change(PythonWrapper(args[i]));
+    return rv;
+}
+
+template<typename ArgsType>
+type::result_map PythonOnlyPropertyType::wrap_results(type::result_map rv,
+                                                      ArgsType&& args) const {
+    if(static_cast<std::size_t>(args.size()) != m_result_order_.size())
+        throw std::runtime_error("PythonOnlyPropertyType \"" + m_name_ +
+                                 "\": wrong number of positional results");
+    for(std::size_t i = 0; i < m_result_order_.size(); ++i)
+        rv.at(m_result_order_[i]).change(PythonWrapper(args[i]));
+    return rv;
+}
+
+} // namespace pluginplay::python

--- a/src/pluginplay/module/detail_/module_pimpl.hpp
+++ b/src/pluginplay/module/detail_/module_pimpl.hpp
@@ -403,6 +403,28 @@ public:
      */
     auto& property_types() const;
 
+    /** @brief Returns the set of Python-only property types (by name) that
+     *         this module can be run as, in a read/write state.
+     *
+     *  @return The set of Python-only property type names that this module
+     *          satisfies.
+     *
+     * @throw std::runtime_error if this PIMPL does not have an implementation.
+     *                           Strong throw guarantee.
+     */
+    auto& python_property_types();
+
+    /** @brief Returns the set of Python-only property types (by name) that
+     *         this module can be run as, in a read-only state.
+     *
+     *  @return The set of Python-only property type names that this module
+     *          satisfies.
+     *
+     * @throw std::runtime_error if this PIMPL does not have an implementation.
+     *                           Strong throw guarantee.
+     */
+    auto& python_property_types() const;
+
     /** @brief Returns the human-readable description provided by the developer
      *
      *  Developers are encouraged to provide human-readable descriptions of what
@@ -643,6 +665,9 @@ private:
 
     /// The set of property types that his module satisfies
     std::set<type::rtti> m_property_types_;
+
+    /// The names of the Python-only property types this module satisfies
+    std::set<std::string> m_python_property_types_;
 
     /// Timer used to time runs of this module
     utilities::Timer m_timer_;

--- a/src/pluginplay/module/detail_/module_pimpl.ipp
+++ b/src/pluginplay/module/detail_/module_pimpl.ipp
@@ -23,7 +23,9 @@ inline ModulePIMPL::ModulePIMPL(base_ptr base, cache_ptr cache) :
   m_cache_(cache),
   m_inputs_(base ? base->inputs() : type::input_map{}),
   m_submods_(base ? base->submods() : type::submodule_map{}),
-  m_property_types_(base ? base->property_types() : std::set<type::rtti>{}) {}
+  m_property_types_(base ? base->property_types() : std::set<type::rtti>{}),
+  m_python_property_types_(base ? base->python_property_types() :
+                                  std::set<std::string>{}) {}
 
 inline bool ModulePIMPL::has_description() const {
     assert_mod_();
@@ -86,6 +88,16 @@ inline auto& ModulePIMPL::property_types() {
 inline auto& ModulePIMPL::property_types() const {
     assert_mod_();
     return m_property_types_;
+}
+
+inline auto& ModulePIMPL::python_property_types() {
+    assert_mod_();
+    return m_python_property_types_;
+}
+
+inline auto& ModulePIMPL::python_property_types() const {
+    assert_mod_();
+    return m_python_property_types_;
 }
 
 inline auto& ModulePIMPL::description() const {
@@ -192,8 +204,9 @@ inline bool ModulePIMPL::operator==(const ModulePIMPL& rhs) const {
     if(locked() != rhs.locked()) return false;
     if(!has_module()) return true;
 
-    if(std::tie(inputs(), submods(), property_types()) !=
-       std::tie(rhs.inputs(), rhs.submods(), rhs.property_types()))
+    if(std::tie(inputs(), submods(), property_types(), python_property_types()) !=
+       std::tie(rhs.inputs(), rhs.submods(), rhs.property_types(),
+                rhs.python_property_types()))
         return false;
     return (*m_base_ == *rhs.m_base_);
 }

--- a/src/pluginplay/module/module.cpp
+++ b/src/pluginplay/module/module.cpp
@@ -101,6 +101,10 @@ const std::set<type::rtti>& Module::property_types() const {
     return m_pimpl_->property_types();
 }
 
+const std::set<std::string>& Module::python_property_types() const {
+    return m_pimpl_->python_property_types();
+}
+
 type::result_map Module::run(type::input_map ps) {
     return m_pimpl_->run(std::move(ps));
 }
@@ -153,6 +157,14 @@ void Module::check_property_type_(type::rtti prop_type) {
 
     std::string msg = "Module does not satisfy property type ";
     msg += utilities::printing::Demangler::demangle(prop_type);
+    throw std::runtime_error(msg);
+}
+
+void Module::check_python_property_type_(const std::string& name) {
+    if(python_property_types().count(name)) return;
+
+    std::string msg =
+      "Module does not satisfy Python-only property type \"" + name + "\"";
     throw std::runtime_error(msg);
 }
 

--- a/src/pluginplay/property_type/python_only_property_type.cpp
+++ b/src/pluginplay/property_type/python_only_property_type.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pluginplay/property_type/python_only_property_type.hpp>
+
+namespace pluginplay::python {
+
+ModuleInput& PythonOnlyPropertyType::declare_input(const type::key& key) {
+    auto& in = m_inputs_[key];
+    in.set_type<PythonWrapper>();
+    m_input_order_.push_back(key);
+    return in;
+}
+
+ModuleResult& PythonOnlyPropertyType::declare_result(const type::key& key) {
+    auto& r = m_results_[key];
+    r.set_type<PythonWrapper>();
+    m_result_order_.push_back(key);
+    return r;
+}
+
+std::vector<PythonWrapper> PythonOnlyPropertyType::unwrap_inputs(
+  const type::input_map& im) const {
+    std::vector<PythonWrapper> rv;
+    rv.reserve(m_input_order_.size());
+    for(const auto& key : m_input_order_)
+        rv.push_back(im.at(key).value<PythonWrapper>());
+    return rv;
+}
+
+std::vector<PythonWrapper> PythonOnlyPropertyType::unwrap_results(
+  const type::result_map& rm) const {
+    std::vector<PythonWrapper> rv;
+    rv.reserve(m_result_order_.size());
+    for(const auto& key : m_result_order_)
+        rv.push_back(rm.at(key).value<PythonWrapper>());
+    return rv;
+}
+
+} // namespace pluginplay::python

--- a/src/python/module/export_module_base.cpp
+++ b/src/python/module/export_module_base.cpp
@@ -16,6 +16,7 @@
 
 #include "../export_pluginplay.hpp"
 #include "py_module_base.hpp"
+#include <pluginplay/property_type/python_only_property_type.hpp>
 
 namespace pluginplay {
 
@@ -38,6 +39,7 @@ void export_module_base(py_module_reference m) {
       .def("inputs", static_cast<inputs_fxn>(&ModuleBase::inputs))
       .def("submods", static_cast<submod_fxn>(&ModuleBase::submods))
       .def("property_types", &ModuleBase::property_types)
+      .def("python_property_types", &ModuleBase::python_property_types)
       .def("get_desc", &ModuleBase::get_desc)
       .def("citations", &ModuleBase::citations)
       .def("get_runtime", &ModuleBase::get_runtime)
@@ -75,6 +77,11 @@ void export_module_base(py_module_reference m) {
         py::return_value_policy::reference)
       .def("satisfies_property_type",
            [](ModuleBase& self, py::object pt) {
+               if(py::isinstance<python::PythonOnlyPropertyType>(pt)) {
+                   self.satisfies_property_type(
+                     pt.cast<const python::PythonOnlyPropertyType&>());
+                   return;
+               }
                auto info    = pt.attr("type")().cast<python::PyTypeInfo>();
                auto inputs  = pt.attr("inputs")().cast<type::input_map>();
                auto results = pt.attr("results")().cast<type::result_map>();

--- a/src/python/module/export_module_class.cpp
+++ b/src/python/module/export_module_class.cpp
@@ -37,8 +37,7 @@ pybind11::object py_module_run_as(Module& self, pybind11::object pt,
 /// Module::run_as(const python::PythonOnlyPropertyType&, ...), which checks
 /// (by name) that the module actually satisfies @p pt before running it.
 pybind11::object py_module_run_as_python_only(
-  Module& self, const python::PythonOnlyPropertyType& pt,
-  pybind11::args args) {
+  Module& self, const python::PythonOnlyPropertyType& pt, pybind11::args args) {
     auto rv = self.run_as(pt, args);
     pybind11::tuple rv_tuple(rv.size());
     for(std::size_t i = 0; i < rv.size(); ++i)

--- a/src/python/module/export_module_class.cpp
+++ b/src/python/module/export_module_class.cpp
@@ -16,6 +16,7 @@
 
 #include "../export_pluginplay.hpp"
 #include <pluginplay/module/module_class.hpp>
+#include <pluginplay/property_type/python_only_property_type.hpp>
 #include <pluginplay/python/py_type_info.hpp>
 #include <pluginplay/submodule_request.hpp>
 
@@ -29,6 +30,21 @@ pybind11::object py_module_run_as(Module& self, pybind11::object pt,
     auto cxx_rvs             = self.run(cxx_inps);
     pybind11::tuple rv_tuple = pt.attr("unwrap_results")(cxx_rvs);
     return rv_tuple.size() != 1 ? rv_tuple : pybind11::object(rv_tuple[0]);
+}
+
+/// Same purpose as py_module_run_as, but for PythonOnlyPropertyType. Unlike
+/// the generic duck-typed path above, this goes through
+/// Module::run_as(const python::PythonOnlyPropertyType&, ...), which checks
+/// (by name) that the module actually satisfies @p pt before running it.
+pybind11::object py_module_run_as_python_only(
+  Module& self, const python::PythonOnlyPropertyType& pt,
+  pybind11::args args) {
+    auto rv = self.run_as(pt, args);
+    pybind11::tuple rv_tuple(rv.size());
+    for(std::size_t i = 0; i < rv.size(); ++i)
+        rv_tuple[i] = rv[i].unwrap<pybind11::object>();
+    return rv_tuple.size() != 1 ? pybind11::object(rv_tuple) :
+                                  pybind11::object(rv_tuple[0]);
 }
 
 void export_module_class(py_module_reference m) {
@@ -67,6 +83,7 @@ void export_module_class(py_module_reference m) {
                    rv.emplace(python::PyTypeInfo(pt));
                return rv;
            })
+      .def("python_property_types", &Module::python_property_types)
       .def("description", &Module::description)
       .def("citations", &Module::citations)
       .def("get_name",
@@ -87,9 +104,20 @@ void export_module_class(py_module_reference m) {
            static_cast<change_submod_fxn>(&Module::change_submod))
       .def("run_as",
            [](Module& self, pybind11::object pt) {
+               if(pybind11::isinstance<python::PythonOnlyPropertyType>(pt))
+                   return py_module_run_as_python_only(
+                     self, pt.cast<const python::PythonOnlyPropertyType&>(),
+                     pybind11::args{});
                return py_module_run_as(self, pt, pybind11::args{});
            })
-      .def("run_as", &py_module_run_as)
+      .def("run_as",
+           [](Module& self, pybind11::object pt, pybind11::args args) {
+               if(pybind11::isinstance<python::PythonOnlyPropertyType>(pt))
+                   return py_module_run_as_python_only(
+                     self, pt.cast<const python::PythonOnlyPropertyType&>(),
+                     std::move(args));
+               return py_module_run_as(self, pt, std::move(args));
+           })
       .def("run", &Module::run)
       .def("profile_info", &Module::profile_info)
       .def("submod_uuids", &Module::submod_uuids)

--- a/src/python/property_type/export_python_only_property_type.cpp
+++ b/src/python/property_type/export_python_only_property_type.cpp
@@ -24,7 +24,8 @@ namespace {
 pybind11::tuple py_unwrap(const std::vector<PythonWrapper>& unwrapped) {
     pybind11::tuple rv(unwrapped.size());
     for(std::size_t i = 0; i < unwrapped.size(); ++i)
-        rv[i] = const_cast<PythonWrapper&>(unwrapped[i]).unwrap<pybind11::object>();
+        rv[i] =
+          const_cast<PythonWrapper&>(unwrapped[i]).unwrap<pybind11::object>();
     return rv;
 }
 

--- a/src/python/property_type/export_python_only_property_type.cpp
+++ b/src/python/property_type/export_python_only_property_type.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../export_pluginplay.hpp"
+#include <pluginplay/property_type/python_only_property_type.hpp>
+
+namespace pluginplay::python {
+
+namespace {
+
+pybind11::tuple py_unwrap(const std::vector<PythonWrapper>& unwrapped) {
+    pybind11::tuple rv(unwrapped.size());
+    for(std::size_t i = 0; i < unwrapped.size(); ++i)
+        rv[i] = const_cast<PythonWrapper&>(unwrapped[i]).unwrap<pybind11::object>();
+    return rv;
+}
+
+} // namespace
+
+void export_python_only_property_type(py_module_reference m) {
+    py_class_type<PythonOnlyPropertyType>(m, "PythonOnlyPropertyType")
+      .def(pybind11::init<std::string>(), pybind11::arg("name"))
+      .def("name", &PythonOnlyPropertyType::name)
+      .def("declare_input", &PythonOnlyPropertyType::declare_input,
+           pybind11::return_value_policy::reference)
+      .def("declare_result", &PythonOnlyPropertyType::declare_result,
+           pybind11::return_value_policy::reference)
+      .def("inputs", &PythonOnlyPropertyType::inputs)
+      .def("results", &PythonOnlyPropertyType::results)
+      .def("input_order", &PythonOnlyPropertyType::input_order)
+      .def("result_order", &PythonOnlyPropertyType::result_order)
+      .def("wrap_inputs",
+           [](PythonOnlyPropertyType& self, type::input_map& inputs,
+              pybind11::args args) {
+               return self.wrap_inputs(inputs, std::move(args));
+           })
+      .def("wrap_results",
+           [](PythonOnlyPropertyType& self, type::result_map& results,
+              pybind11::args args) {
+               return self.wrap_results(results, std::move(args));
+           })
+      .def("unwrap_inputs",
+           [](PythonOnlyPropertyType& self, const type::input_map& inputs) {
+               return py_unwrap(self.unwrap_inputs(inputs));
+           })
+      .def("unwrap_results",
+           [](PythonOnlyPropertyType& self, const type::result_map& results) {
+               return py_unwrap(self.unwrap_results(results));
+           });
+}
+
+} // namespace pluginplay::python

--- a/src/python/python/export_python.hpp
+++ b/src/python/python/export_python.hpp
@@ -21,10 +21,12 @@ namespace pluginplay::python {
 
 void export_py_type_info(py_module_reference m);
 void export_python_wrapper(py_module_reference m);
+void export_python_only_property_type(py_module_reference m);
 
 inline void export_python(py_module_reference m) {
     export_py_type_info(m);
     export_python_wrapper(m);
+    export_python_only_property_type(m);
 }
 
 } // namespace pluginplay::python

--- a/tests/cxx/unit_tests/pluginplay/module/module_base.cpp
+++ b/tests/cxx/unit_tests/pluginplay/module/module_base.cpp
@@ -100,9 +100,10 @@ TEST_CASE("ModuleBase : python_property_types()") {
     }
     SECTION("Has a Python-only property type") {
         testing::PythonOnlyPTModule mod;
-        REQUIRE(mod.python_property_types() == std::set<std::string>{"PydanticAPI"});
+        REQUIRE(mod.python_property_types() ==
+                std::set<std::string>{"PydanticAPI"});
         REQUIRE(mod.property_types() ==
-               std::set{type::rtti{typeid(python::PythonOnlyPropertyType)}});
+                std::set{type::rtti{typeid(python::PythonOnlyPropertyType)}});
         REQUIRE(mod.inputs().count("input schema") == 1);
         REQUIRE(mod.results().count("result schema") == 1);
     }

--- a/tests/cxx/unit_tests/pluginplay/module/module_base.cpp
+++ b/tests/cxx/unit_tests/pluginplay/module/module_base.cpp
@@ -93,6 +93,21 @@ TEST_CASE("ModuleBase : property_types()") {
     }
 }
 
+TEST_CASE("ModuleBase : python_property_types()") {
+    SECTION("No Python-only property type") {
+        testing::NoPTModule mod;
+        REQUIRE(mod.python_property_types().empty());
+    }
+    SECTION("Has a Python-only property type") {
+        testing::PythonOnlyPTModule mod;
+        REQUIRE(mod.python_property_types() == std::set<std::string>{"PydanticAPI"});
+        REQUIRE(mod.property_types() ==
+               std::set{type::rtti{typeid(python::PythonOnlyPropertyType)}});
+        REQUIRE(mod.inputs().count("input schema") == 1);
+        REQUIRE(mod.results().count("result schema") == 1);
+    }
+}
+
 TEST_CASE("ModuleBase : type") {
     testing::NotReadyModule mod;
     REQUIRE(mod.type() == type::rtti(typeid(testing::NotReadyModule)));

--- a/tests/cxx/unit_tests/pluginplay/module/module_class.cpp
+++ b/tests/cxx/unit_tests/pluginplay/module/module_class.cpp
@@ -18,6 +18,9 @@
 #include "test_common.hpp"
 #include <pluginplay/module/module_class.hpp>
 #include <regex>
+#ifdef BUILD_PYBIND11
+#include <pybind11/pybind11.h>
+#endif
 
 using namespace pluginplay;
 using namespace testing;
@@ -275,6 +278,37 @@ TEST_CASE("Module : property_types") {
         REQUIRE(mod->property_types() == std::set{type::rtti{typeid(NullPT)}});
     }
 }
+
+TEST_CASE("Module : python_property_types") {
+    SECTION("Throws if no implementation") {
+        Module p;
+        REQUIRE_THROWS_AS(p.python_property_types(), std::runtime_error);
+    }
+    SECTION("No Python-only property types") {
+        auto mod = make_module<NullModule>();
+        REQUIRE(mod->python_property_types().empty());
+    }
+    SECTION("Has a Python-only property type") {
+        auto mod = make_module<PythonOnlyPTModule>();
+        REQUIRE(mod->python_property_types() == std::set<std::string>{"PydanticAPI"});
+        // Also visible (shared marker) via the ordinary RTTI-keyed set
+        REQUIRE(mod->property_types() ==
+               std::set{type::rtti{typeid(python::PythonOnlyPropertyType)}});
+    }
+}
+
+#ifdef BUILD_PYBIND11
+TEST_CASE("Module : run_as(PythonOnlyPropertyType)") {
+    SECTION("Throws if module does not satisfy the property type") {
+        auto mod = make_module<NullModule>();
+        python::PythonOnlyPropertyType pt("PydanticAPI");
+        // check_python_property_type_ throws before touching args, so it's
+        // safe to pass a default-constructed (empty-handle) args here even
+        // without an initialized Python interpreter.
+        REQUIRE_THROWS_AS(mod->run_as(pt, pybind11::args{}), std::runtime_error);
+    }
+}
+#endif
 
 TEST_CASE("Module : change_input") {
     const std::string key{"Option 1"};

--- a/tests/cxx/unit_tests/pluginplay/module/module_class.cpp
+++ b/tests/cxx/unit_tests/pluginplay/module/module_class.cpp
@@ -290,10 +290,11 @@ TEST_CASE("Module : python_property_types") {
     }
     SECTION("Has a Python-only property type") {
         auto mod = make_module<PythonOnlyPTModule>();
-        REQUIRE(mod->python_property_types() == std::set<std::string>{"PydanticAPI"});
+        REQUIRE(mod->python_property_types() ==
+                std::set<std::string>{"PydanticAPI"});
         // Also visible (shared marker) via the ordinary RTTI-keyed set
         REQUIRE(mod->property_types() ==
-               std::set{type::rtti{typeid(python::PythonOnlyPropertyType)}});
+                std::set{type::rtti{typeid(python::PythonOnlyPropertyType)}});
     }
 }
 
@@ -305,7 +306,8 @@ TEST_CASE("Module : run_as(PythonOnlyPropertyType)") {
         // check_python_property_type_ throws before touching args, so it's
         // safe to pass a default-constructed (empty-handle) args here even
         // without an initialized Python interpreter.
-        REQUIRE_THROWS_AS(mod->run_as(pt, pybind11::args{}), std::runtime_error);
+        REQUIRE_THROWS_AS(mod->run_as(pt, pybind11::args{}),
+                          std::runtime_error);
     }
 }
 #endif

--- a/tests/cxx/unit_tests/pluginplay/property_type/python_only_property_type.cpp
+++ b/tests/cxx/unit_tests/pluginplay/property_type/python_only_property_type.cpp
@@ -51,12 +51,12 @@ TEST_CASE("PythonOnlyPropertyType") {
         REQUIRE(pt.inputs().count("input schema") == 1);
         REQUIRE(pt.input_order() == std::vector<type::key>{"input schema"});
         REQUIRE(pt.inputs().at("input schema").description() ==
-               "A pydantic BaseModel instance");
+                "A pydantic BaseModel instance");
 
         SECTION("multiple inputs preserve declaration order") {
             pt.declare_input("another input");
             REQUIRE(pt.input_order() ==
-                   std::vector<type::key>{"input schema", "another input"});
+                    std::vector<type::key>{"input schema", "another input"});
         }
     }
 
@@ -67,6 +67,6 @@ TEST_CASE("PythonOnlyPropertyType") {
         REQUIRE(pt.results().count("result schema") == 1);
         REQUIRE(pt.result_order() == std::vector<type::key>{"result schema"});
         REQUIRE(pt.results().at("result schema").description() ==
-               "A pydantic BaseModel instance");
+                "A pydantic BaseModel instance");
     }
 }

--- a/tests/cxx/unit_tests/pluginplay/property_type/python_only_property_type.cpp
+++ b/tests/cxx/unit_tests/pluginplay/property_type/python_only_property_type.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 NWChemEx-Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../catch.hpp"
+#include <pluginplay/property_type/python_only_property_type.hpp>
+
+using namespace pluginplay;
+using namespace pluginplay::python;
+
+/** Testing Notes.
+ *
+ *  Without a running Python interpreter we can not safely create live Python
+ *  objects (or a non-empty pybind11::args instance -- default-constructing
+ *  one is safe, but calling methods like size() on it is not). This test
+ *  therefore focuses on the parts of PythonOnlyPropertyType that don't
+ *  require live Python values: name(), field declaration, and the
+ *  inputs()/results()/input_order()/result_order() accessors. The
+ *  wrap_inputs/wrap_results/unwrap_inputs/unwrap_results round trip (which
+ *  needs real Python objects) is exercised by the corresponding Python unit
+ *  test.
+ */
+TEST_CASE("PythonOnlyPropertyType") {
+    PythonOnlyPropertyType pt("PydanticAPI");
+
+    SECTION("name") { REQUIRE(pt.name() == "PydanticAPI"); }
+
+    SECTION("no fields by default") {
+        REQUIRE(pt.inputs().empty());
+        REQUIRE(pt.results().empty());
+        REQUIRE(pt.input_order().empty());
+        REQUIRE(pt.result_order().empty());
+    }
+
+    SECTION("declare_input") {
+        auto& in = pt.declare_input("input schema");
+        in.set_description("A pydantic BaseModel instance");
+
+        REQUIRE(pt.inputs().count("input schema") == 1);
+        REQUIRE(pt.input_order() == std::vector<type::key>{"input schema"});
+        REQUIRE(pt.inputs().at("input schema").description() ==
+               "A pydantic BaseModel instance");
+
+        SECTION("multiple inputs preserve declaration order") {
+            pt.declare_input("another input");
+            REQUIRE(pt.input_order() ==
+                   std::vector<type::key>{"input schema", "another input"});
+        }
+    }
+
+    SECTION("declare_result") {
+        auto& r = pt.declare_result("result schema");
+        r.set_description("A pydantic BaseModel instance");
+
+        REQUIRE(pt.results().count("result schema") == 1);
+        REQUIRE(pt.result_order() == std::vector<type::key>{"result schema"});
+        REQUIRE(pt.results().at("result schema").description() ==
+               "A pydantic BaseModel instance");
+    }
+}

--- a/tests/cxx/unit_tests/pluginplay/test_common.hpp
+++ b/tests/cxx/unit_tests/pluginplay/test_common.hpp
@@ -19,6 +19,7 @@
 #include <pluginplay/module/detail_/module_pimpl.hpp>
 #include <pluginplay/module/macros.hpp>
 #include <pluginplay/module/module_class.hpp>
+#include <pluginplay/property_type/python_only_property_type.hpp>
 #include <pluginplay/utility/uuid.hpp>
 
 namespace testing {
@@ -38,6 +39,17 @@ inline MODULE_RUN(NoPTModule) { return results(); }
 DECLARE_MODULE(NullModule);
 inline MODULE_CTOR(NullModule) { satisfies_property_type<NullPT>(); }
 inline MODULE_RUN(NullModule) { return results(); }
+
+// Module satisfying a Python-only property type named "PydanticAPI", with
+// one input ("input schema") and one result ("result schema")
+DECLARE_MODULE(PythonOnlyPTModule);
+inline MODULE_CTOR(PythonOnlyPTModule) {
+    pluginplay::python::PythonOnlyPropertyType pt("PydanticAPI");
+    pt.declare_input("input schema");
+    pt.declare_result("result schema");
+    satisfies_property_type(pt);
+}
+inline MODULE_RUN(PythonOnlyPTModule) { return results(); }
 
 // Module with a description "A description"
 DECLARE_MODULE(DescModule);

--- a/tests/python/unit_tests/property_type/test_python_only_property_type.py
+++ b/tests/python/unit_tests/property_type/test_python_only_property_type.py
@@ -16,6 +16,7 @@ import unittest
 
 import pluginplay as pp
 
+
 class PydanticAPI(pp.PythonOnlyPropertyType):
     """A Python-only property type with one input, "input schema", and one
     result, "result schema", each an opaque Python object. A real module would
@@ -67,7 +68,9 @@ class TestPythonOnlyPropertyType(unittest.TestCase):
         self.assertEqual(unwrapped, {"y": 2})
 
     def test_module_satisfies_and_runs(self):
-        mod = EchoModule()
+        mm = pp.ModuleManager()
+        mm.add_module("echo", EchoModule())
+        mod = mm.at("echo")
         self.assertIn("PydanticAPI", mod.python_property_types())
 
         # Round-trips a Python object through the module, exercising the
@@ -83,7 +86,9 @@ class TestPythonOnlyPropertyType(unittest.TestCase):
             def run_(self, inputs, submods):
                 return self.results()
 
-        mod = NotPydanticModule()
+        mm = pp.ModuleManager()
+        mm.add_module("not pydantic", NotPydanticModule())
+        mod = mm.at("not pydantic")
         with self.assertRaises(RuntimeError):
             mod.run_as(self.pt, {"x": 1})
 

--- a/tests/python/unit_tests/property_type/test_python_only_property_type.py
+++ b/tests/python/unit_tests/property_type/test_python_only_property_type.py
@@ -1,0 +1,91 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import pluginplay as pp
+
+class PydanticAPI(pp.PythonOnlyPropertyType):
+    """A Python-only property type with one input, "input schema", and one
+    result, "result schema", each an opaque Python object. A real module would
+    typically constrain these to specific pydantic BaseModel subclasses; any
+    Python object works for the mechanism itself, which is exercised here with
+    plain dicts to avoid a pydantic dependency in this test.
+    """
+
+    def __init__(self):
+        pp.PythonOnlyPropertyType.__init__(self, "PydanticAPI")
+        self.declare_input("input schema").set_description(
+            "A pydantic BaseModel instance"
+        )
+        self.declare_result("result schema").set_description(
+            "A pydantic BaseModel instance"
+        )
+
+
+class EchoModule(pp.ModuleBase):
+    def __init__(self):
+        pp.ModuleBase.__init__(self)
+        self.satisfies_property_type(PydanticAPI())
+
+    def run_(self, inputs, submods):
+        pt = PydanticAPI()
+        (input_value,) = pt.unwrap_inputs(inputs)
+        rv = self.results()
+        return pt.wrap_results(rv, {"echo": input_value})
+
+
+class TestPythonOnlyPropertyType(unittest.TestCase):
+    def test_name(self):
+        self.assertEqual(self.pt.name(), "PydanticAPI")
+
+    def test_declare_input_and_result(self):
+        self.assertEqual(list(self.pt.inputs().keys()), ["input schema"])
+        self.assertEqual(list(self.pt.results().keys()), ["result schema"])
+        self.assertEqual(self.pt.input_order(), ["input schema"])
+        self.assertEqual(self.pt.result_order(), ["result schema"])
+
+    def test_wrap_and_unwrap_inputs(self):
+        wrapped = self.pt.wrap_inputs(self.pt.inputs(), {"x": 1})
+        (unwrapped,) = self.pt.unwrap_inputs(wrapped)
+        self.assertEqual(unwrapped, {"x": 1})
+
+    def test_wrap_and_unwrap_results(self):
+        wrapped = self.pt.wrap_results(self.pt.results(), {"y": 2})
+        (unwrapped,) = self.pt.unwrap_results(wrapped)
+        self.assertEqual(unwrapped, {"y": 2})
+
+    def test_module_satisfies_and_runs(self):
+        mod = EchoModule()
+        self.assertIn("PydanticAPI", mod.python_property_types())
+
+        # Round-trips a Python object through the module, exercising the
+        # ordinary Module::run() pipeline (via run_as) -- not a bypass path.
+        result = mod.run_as(self.pt, {"x": 1})
+        self.assertEqual(result, {"echo": {"x": 1}})
+
+    def test_run_as_throws_if_not_satisfied(self):
+        class NotPydanticModule(pp.ModuleBase):
+            def __init__(self):
+                pp.ModuleBase.__init__(self)
+
+            def run_(self, inputs, submods):
+                return self.results()
+
+        mod = NotPydanticModule()
+        with self.assertRaises(RuntimeError):
+            mod.run_as(self.pt, {"x": 1})
+
+    def setUp(self):
+        self.pt = PydanticAPI()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
For a long time we've only had the ability to declare property types in C++. This PR introduces a mechanism for declaring Python-only PTs. PTs declared this way can only be leveraged by modules written in Python. Python-only PTs are duck-typing compatible and largely amount to labeling arguments and enforcing numbers of inputs/results. 

FWIW the motivation for this PR is that I need to declare an API compatible with the QCArchive ecosystem which requires me to take/return Pydantic objects, which are pure Python objects. I thus can't declare a C++ property type for such a module.

**TODOs**
None (if tests pass)
